### PR TITLE
Implement integration with schema register and fix several other issues.

### DIFF
--- a/src/bin/set_summary_state.rs
+++ b/src/bin/set_summary_state.rs
@@ -60,9 +60,9 @@ async fn main() {
         cli.get_configuration_override()
     );
 
-    let domain = domain::Domain::new();
+    let mut domain = domain::Domain::new();
     let mut remote = Remote::from_name_index(
-        &domain,
+        &mut domain,
         &cli.get_component_name(),
         cli.get_component_index(),
     );

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -1,9 +1,15 @@
-use std::process;
+use kafka::client::KafkaClient;
+use kafka::error::Error as KafkaError;
+use std::{process, thread, time::Duration};
 use whoami;
+
+const MAX_ITER_LOAD_METADATA: u8 = 5;
+const POOL_CLIENT_WAIT_TIME: Duration = Duration::from_millis(500);
 
 pub struct Domain {
     origin: u32,
     identity: Option<String>,
+    kafka_client: KafkaClient,
 }
 
 impl Domain {
@@ -12,6 +18,7 @@ impl Domain {
         Domain {
             origin: process::id(),
             identity: None,
+            kafka_client: KafkaClient::new(Domain::get_client_hosts()),
         }
     }
 
@@ -31,6 +38,46 @@ impl Domain {
             Some(identity) => identity.to_owned(),
             None => self.get_default_identity(),
         }
+    }
+
+    /// Register topics.
+    pub fn register_topics<T: AsRef<str>>(&mut self, topics: &[T]) -> Result<(), KafkaError> {
+        for _ in 0..MAX_ITER_LOAD_METADATA {
+            let result = self.kafka_client.load_metadata(topics);
+            match result {
+                Ok(_) => {
+                    let partitions_unloaded: Vec<bool> = topics
+                        .iter()
+                        .filter_map(|topic| {
+                            if self
+                                .kafka_client
+                                .topics()
+                                .partitions(topic.as_ref().into())
+                                .map(|p| p.len())
+                                .unwrap_or(0)
+                                > 0
+                            {
+                                None
+                            } else {
+                                Some(true)
+                            }
+                        })
+                        .collect();
+                    if partitions_unloaded.is_empty() {
+                        return Ok(());
+                    }
+                }
+                Err(err) => return Err(err),
+            }
+            thread::sleep(POOL_CLIENT_WAIT_TIME);
+        }
+        Ok(())
+    }
+
+    /// Get client host address.
+    pub fn get_client_hosts() -> Vec<String> {
+        // FIXME: Handle general case (tribeiro/rs_salobj#42).
+        vec!["localhost:9092".to_owned()]
     }
 }
 

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -27,7 +27,7 @@ pub struct Remote<'a> {
 
 impl<'a> Remote<'a> {
     pub fn new(
-        domain: &domain::Domain,
+        domain: &mut domain::Domain,
         name: &str,
         index: isize,
         readonly: bool,
@@ -45,6 +45,8 @@ impl<'a> Remote<'a> {
         }
 
         let sal_info = sal_info::SalInfo::new(&name, index);
+
+        domain.register_topics(&sal_info.get_topics_name()).unwrap();
 
         let commands: HashMap<String, RemoteCommand> = if readonly {
             HashMap::new()
@@ -91,7 +93,7 @@ impl<'a> Remote<'a> {
         }
     }
 
-    pub fn from_name_index(domain: &domain::Domain, name: &str, index: isize) -> Remote<'a> {
+    pub fn from_name_index(domain: &mut domain::Domain, name: &str, index: isize) -> Remote<'a> {
         Remote::new(domain, name, index, false, Vec::new(), Vec::new(), 1)
     }
 
@@ -160,20 +162,20 @@ mod tests {
     use super::*;
     #[test]
     fn test_get_name() {
-        let domain = domain::Domain::new();
+        let mut domain = domain::Domain::new();
         let name = "Test";
         let index = 1;
-        let remote = Remote::from_name_index(&domain, name, index);
+        let remote = Remote::from_name_index(&mut domain, name, index);
 
         assert_eq!("Test", remote.get_name())
     }
 
     #[test]
     fn test_get_index() {
-        let domain = domain::Domain::new();
+        let mut domain = domain::Domain::new();
         let name = "Test";
         let index = 1;
-        let remote = Remote::from_name_index(&domain, name, index);
+        let remote = Remote::from_name_index(&mut domain, name, index);
 
         assert_eq!(index, remote.get_index());
     }

--- a/src/sal_subsystem.rs
+++ b/src/sal_subsystem.rs
@@ -107,7 +107,12 @@ impl SALSubsystemInfo {
             .filter_map(|(name, sal_topic)| {
                 Some((
                     name,
-                    TopicInfo::from_sal_topic(&sal_topic, topic_subname, self.indexed),
+                    TopicInfo::from_generic_sal_topic(
+                        &sal_topic,
+                        topic_subname,
+                        self.indexed,
+                        &self.name,
+                    ),
                 ))
             })
             .collect()
@@ -144,7 +149,12 @@ impl SALSubsystemInfo {
             .filter_map(|(name, sal_topic)| {
                 Some((
                     name,
-                    TopicInfo::from_sal_topic(&sal_topic, topic_subname, self.indexed),
+                    TopicInfo::from_generic_sal_topic(
+                        &sal_topic,
+                        topic_subname,
+                        self.indexed,
+                        &self.name,
+                    ),
                 ))
             })
             .collect()

--- a/src/topics/field_info.rs
+++ b/src/topics/field_info.rs
@@ -1,4 +1,9 @@
-use std::fmt;
+use std::{
+    collections::BTreeMap,
+    fmt::{self, Debug},
+};
+
+use serde::{ser::SerializeStruct, Deserialize, Serialize, Serializer};
 
 extern crate serde;
 
@@ -19,14 +24,36 @@ pub enum SalType {
 }
 
 /// Avro Schema field.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Deserialize, Debug)]
 pub struct AvroSchemaField {
     name: String,
-    #[serde(rename = "type")]
-    avro_type: String,
-    default: String,
+    // #[serde(rename = "type")]
+    avro_type: BTreeMap<String, String>,
+    default: Vec<String>,
     description: String,
     units: String,
+    // #[serde(skip)]
+    scalar: bool,
+}
+
+impl Serialize for AvroSchemaField {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut avro_schema_field = serializer.serialize_struct("AvroSchemaField", 5)?;
+        avro_schema_field.serialize_field("name", &self.name)?;
+        if self.scalar {
+            avro_schema_field.serialize_field("type", &self.avro_type.get("items"))?;
+            avro_schema_field.serialize_field("default", &self.default[0])?;
+        } else {
+            avro_schema_field.serialize_field("type", &self.avro_type)?;
+            avro_schema_field.serialize_field("default", &self.default)?;
+        }
+        avro_schema_field.serialize_field("description", &self.description)?;
+        avro_schema_field.serialize_field("units", &self.units)?;
+        avro_schema_field.end()
+    }
 }
 
 /// Information about one field of a topic.
@@ -86,14 +113,26 @@ impl FieldInfo {
         }
     }
 
+    /// Get field name.
+    pub fn get_name(&self) -> String {
+        self.name.to_owned()
+    }
+
+    /// Make avro schema for the field.
     pub fn make_avro_schema(&self) -> AvroSchemaField {
         AvroSchemaField {
             name: self.name.to_owned(),
-            avro_type: FieldInfo::get_avro_type_from_sal_type(&self.sal_type).to_owned(),
-            default: self.default_scalar_value.to_string(),
+            avro_type: FieldInfo::get_avro_array_type(&self.sal_type),
+            default: self.get_default_value(),
             description: self.description.to_owned(),
             units: self.units.to_owned(),
+            scalar: self.is_scalar(),
         }
+    }
+
+    /// Get default value.
+    fn get_default_value(&self) -> Vec<String> {
+        vec![self.default_scalar_value.to_string(); self.count]
     }
 
     /// Return the default value for the specified sal type.
@@ -116,10 +155,10 @@ impl FieldInfo {
     }
 
     /// Return the avro type name from the sal type name.
-    fn get_avro_type_from_sal_type(sal_type: &str) -> &str {
-        match sal_type {
+    fn get_avro_scalar_type(sal_type: &str) -> String {
+        let scalar_type = match sal_type {
             "boolean" => "boolean",
-            "byte" => "bytes",
+            "byte" => "int",
             "short" => "int",
             "int" => "int",
             "long" => "long",
@@ -131,7 +170,25 @@ impl FieldInfo {
             "double" => "double",
             "string" => "string",
             _ => panic!("Unrecognized SAL type '{sal_type}'"),
-        }
+        };
+
+        scalar_type.to_owned()
+    }
+
+    /// Return the avro type name from the sal type name.
+    fn get_avro_array_type(sal_type: &str) -> BTreeMap<String, String> {
+        BTreeMap::from([
+            ("type".to_owned(), "array".to_owned()),
+            (
+                "items".to_owned(),
+                FieldInfo::get_avro_scalar_type(sal_type),
+            ),
+        ])
+    }
+
+    /// Is this field value scalar?
+    pub fn is_scalar(&self) -> bool {
+        self.count == 1 || self.sal_type == "string"
     }
 }
 
@@ -141,15 +198,26 @@ mod tests {
     use serde_json;
 
     #[test]
-    fn make_avro_schema() {
+    fn make_avro_schema_scalar() {
         let field_info = FieldInfo::new("value", "string", 1, "unitless", "Test value.");
 
-        let avro_schema = field_info.make_avro_schema();
+        let avro_schema: AvroSchemaField = field_info.make_avro_schema();
         let avro_schema_str = serde_json::to_string(&avro_schema).unwrap();
 
         assert_eq!(
             avro_schema_str,
             r#"{"name":"value","type":"string","default":"","description":"Test value.","units":"unitless"}"#
+        )
+    }
+    #[test]
+    fn make_avro_schema_array() {
+        let field_info = FieldInfo::new("value", "float", 5, "unitless", "Test value.");
+
+        let avro_schema: AvroSchemaField = field_info.make_avro_schema();
+        let avro_schema_str = serde_json::to_string(&avro_schema).unwrap();
+        assert_eq!(
+            avro_schema_str,
+            r#"{"name":"value","type":{"items":"float","type":"array"},"default":["0","0","0","0","0"],"description":"Test value.","units":"unitless"}"#
         )
     }
 }

--- a/src/topics/read_topic.rs
+++ b/src/topics/read_topic.rs
@@ -214,10 +214,20 @@ mod tests {
         ReadTopic::new("scalars", &sal_info, &domain, 2);
     }
 
-    #[test]
-    fn get_no_data() {
-        let domain = Domain::new();
+    #[tokio::test]
+    async fn get_no_data() {
+        let mut domain = Domain::new();
         let sal_info = SalInfo::new("Test", 1);
+
+        let topics: Vec<String> = sal_info
+            .get_telemetry_names()
+            .into_iter()
+            .map(|topic_name| sal_info.make_topic_name(&topic_name).to_owned())
+            .collect();
+
+        println!("Loading metadata for topics: {topics:?}");
+        domain.register_topics(&topics).unwrap();
+        sal_info.register_schema().await;
 
         let read_topic = ReadTopic::new("scalars", &sal_info, &domain, 0);
 

--- a/src/topics/topic_info.rs
+++ b/src/topics/topic_info.rs
@@ -77,13 +77,12 @@ impl TopicInfo {
 
     /// Make avro schema for the topic.
     pub fn make_avro_schema(&self) -> AvroSchema {
-        let topic_subname = &self.topic_subname;
         let component_name = &self.component_name;
 
         AvroSchema {
             avro_message_type: "record".to_owned(),
             name: self.topic_name.to_owned(),
-            namespace: format!("lsst.sal.{topic_subname}.{component_name}"),
+            namespace: format!("lsst.sal.kafka-{component_name}"),
             fields: self
                 .fields
                 .iter()

--- a/src/topics/topic_info.rs
+++ b/src/topics/topic_info.rs
@@ -1,13 +1,13 @@
 use crate::topics::field_info;
 use crate::topics::sal_objects::SalTopic;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 /// Information about one topic.
 pub struct TopicInfo {
     component_name: String,
     topic_subname: String,
     topic_name: String,
-    fields: HashMap<String, field_info::FieldInfo>,
+    fields: BTreeMap<String, field_info::FieldInfo>,
     description: String,
     partitions: usize,
 }
@@ -30,7 +30,7 @@ impl TopicInfo {
             component_name: String::new(),
             topic_subname: String::new(),
             topic_name: String::new(),
-            fields: HashMap::new(),
+            fields: BTreeMap::new(),
             description: String::new(),
             partitions: 0,
         }
@@ -41,7 +41,7 @@ impl TopicInfo {
             component_name: String::from(component_name),
             topic_subname: String::from(topic_subname),
             topic_name: String::from("ackcmd"),
-            fields: TopicInfo::get_ackcmd_fields(indexed),
+            fields: TopicInfo::get_ackcmd_fields(indexed).into_iter().collect(),
             description: String::from("Command acknowledgement"),
             partitions: 1,
         }

--- a/src/topics/topic_info.rs
+++ b/src/topics/topic_info.rs
@@ -63,6 +63,27 @@ impl TopicInfo {
         }
     }
 
+    /// Create topic info from `SalTopic`.
+    pub fn from_generic_sal_topic(
+        sal_topic: &SalTopic,
+        topic_subname: &str,
+        indexed: bool,
+        component_name: &str,
+    ) -> TopicInfo {
+        let private_fields = TopicInfo::get_private_fields(indexed);
+
+        let fields: HashMap<String, field_info::FieldInfo> = sal_topic.get_field_info();
+
+        TopicInfo {
+            component_name: component_name.to_owned(),
+            topic_subname: String::from(topic_subname),
+            topic_name: sal_topic.get_topic_name(),
+            fields: private_fields.into_iter().chain(fields).collect(),
+            description: sal_topic.get_description(),
+            partitions: 1,
+        }
+    }
+
     pub fn get_topic_name(&self) -> &str {
         &self.topic_name
     }


### PR DESCRIPTION
While implementing the schema register feature (which ended up being quite a small part of this issue) I found several important bugs hidden in the module. These includes:

* Malformed avro schema for topics with array values.
* Non-registration of topics.

Both issues above were fixed as part of this issue. The library now can run standalone, and does not require the python library to register the topics and schema before it can work. 