### PR TITLE
Sanitize topic name references.

### DIFF
--- a/src/domain.rs
+++ b/src/domain.rs
@@ -1,3 +1,11 @@
+//! Stores information and behavior shared by all clients.
+//!
+//! The [Domain] struct and its implementation stores information about the
+//! client identity and origin and holds an instance to the kafka client.
+//!
+//! When developing applications with salobj you will want to reduce the number
+//! of [Domain] instances, ideally having only one per application.
+
 use kafka::client::KafkaClient;
 use kafka::error::Error as KafkaError;
 use std::env;

--- a/src/generics/auth_list.rs
+++ b/src/generics/auth_list.rs
@@ -55,7 +55,7 @@ mod tests {
             })
             .collect();
 
-        let topic_schema = avro_schema.get("Test_logevent_authList").unwrap();
+        let topic_schema = avro_schema.get("logevent_authList").unwrap();
         let mut topic_record = Record::new(&topic_schema).unwrap();
 
         topic_record.put("authorizedUsers", Value::String("user@hostname".to_owned()));

--- a/src/generics/configuration_applied.rs
+++ b/src/generics/configuration_applied.rs
@@ -67,9 +67,7 @@ mod tests {
             })
             .collect();
 
-        let topic_schema = avro_schema
-            .get("Test_logevent_configurationApplied")
-            .unwrap();
+        let topic_schema = avro_schema.get("logevent_configurationApplied").unwrap();
         let mut topic_record = Record::new(&topic_schema).unwrap();
 
         topic_record.put(

--- a/src/generics/configurations_available.rs
+++ b/src/generics/configurations_available.rs
@@ -62,9 +62,7 @@ mod tests {
             })
             .collect();
 
-        let topic_schema = avro_schema
-            .get("Test_logevent_configurationsAvailable")
-            .unwrap();
+        let topic_schema = avro_schema.get("logevent_configurationsAvailable").unwrap();
         let mut topic_record = Record::new(&topic_schema).unwrap();
 
         topic_record.put(

--- a/src/generics/disable.rs
+++ b/src/generics/disable.rs
@@ -42,7 +42,7 @@ mod tests {
             })
             .collect();
 
-        let topic_schema = avro_schema.get("Test_command_disable").unwrap();
+        let topic_schema = avro_schema.get("command_disable").unwrap();
         let mut topic_record = Record::new(&topic_schema).unwrap();
 
         topic_record.put("private_sndStamp", Value::Double(1.234));

--- a/src/generics/enable.rs
+++ b/src/generics/enable.rs
@@ -42,7 +42,7 @@ mod tests {
             })
             .collect();
 
-        let topic_schema = avro_schema.get("Test_command_enable").unwrap();
+        let topic_schema = avro_schema.get("command_enable").unwrap();
         let mut topic_record = Record::new(&topic_schema).unwrap();
 
         topic_record.put("private_sndStamp", Value::Double(1.234));

--- a/src/generics/enter_control.rs
+++ b/src/generics/enter_control.rs
@@ -42,7 +42,7 @@ mod tests {
             })
             .collect();
 
-        let topic_schema = avro_schema.get("ATCamera_command_enterControl").unwrap();
+        let topic_schema = avro_schema.get("command_enterControl").unwrap();
         let mut topic_record = Record::new(&topic_schema).unwrap();
 
         topic_record.put("private_sndStamp", Value::Double(1.234));

--- a/src/generics/error_code.rs
+++ b/src/generics/error_code.rs
@@ -59,7 +59,7 @@ mod tests {
             })
             .collect();
 
-        let topic_schema = avro_schema.get("Test_logevent_errorCode").unwrap();
+        let topic_schema = avro_schema.get("logevent_errorCode").unwrap();
         let mut topic_record = Record::new(&topic_schema).unwrap();
 
         topic_record.put("errorCode", Value::Long(0));

--- a/src/generics/exit_control.rs
+++ b/src/generics/exit_control.rs
@@ -42,7 +42,7 @@ mod tests {
             })
             .collect();
 
-        let topic_schema = avro_schema.get("Test_command_exitControl").unwrap();
+        let topic_schema = avro_schema.get("command_exitControl").unwrap();
         let mut topic_record = Record::new(&topic_schema).unwrap();
 
         topic_record.put("private_sndStamp", Value::Double(1.234));

--- a/src/generics/heartbeat.rs
+++ b/src/generics/heartbeat.rs
@@ -49,7 +49,7 @@ mod tests {
             })
             .collect();
 
-        let topic_schema = avro_schema.get("Test_logevent_heartbeat").unwrap();
+        let topic_schema = avro_schema.get("logevent_heartbeat").unwrap();
         let mut topic_record = Record::new(&topic_schema).unwrap();
 
         topic_record.put("heartbeat", Value::Boolean(false));

--- a/src/generics/large_file_object_available.rs
+++ b/src/generics/large_file_object_available.rs
@@ -77,7 +77,7 @@ mod tests {
             .collect();
 
         let topic_schema = avro_schema
-            .get("Script_logevent_largeFileObjectAvailable")
+            .get("logevent_largeFileObjectAvailable")
             .unwrap();
         let mut topic_record = Record::new(&topic_schema).unwrap();
 

--- a/src/generics/log_level.rs
+++ b/src/generics/log_level.rs
@@ -53,7 +53,7 @@ mod tests {
             })
             .collect();
 
-        let topic_schema = avro_schema.get("Test_logevent_logLevel").unwrap();
+        let topic_schema = avro_schema.get("logevent_logLevel").unwrap();
         let mut topic_record = Record::new(&topic_schema).unwrap();
 
         topic_record.put("level", Value::Int(0));

--- a/src/generics/log_message.rs
+++ b/src/generics/log_message.rs
@@ -84,7 +84,7 @@ mod tests {
             })
             .collect();
 
-        let schema = avro_schema.get("Test_logevent_logMessage").unwrap();
+        let schema = avro_schema.get("logevent_logMessage").unwrap();
         let mut record = Record::new(&schema).unwrap();
 
         record.put("name", Value::String("Test".to_owned()));

--- a/src/generics/mod.rs
+++ b/src/generics/mod.rs
@@ -1,3 +1,34 @@
+//! Define structs for all generic topics.
+//!
+//! Generic topics are common topics shared by all SAL components. Most of
+//! these topics are opt-in, although some are mandatory. Having these topics
+//! defined as structs allow us to use [serde] to serialize/deserialize the
+//! topics directly into structs.
+//!
+//! All topics must implement the
+//! [BaseTopic](crate::topics::base_topic::BaseTopic) trait. This can be done
+//! with the [base_topic](crate::base_topic) macro, so long as the struct adhere to the
+//! [base topic](crate::topics::base_topic) definition.
+//!
+//! At a minimum a base topic struct will have the following fields:
+//!
+//! ```
+//! use salobj::utils::xml_utils::get_default_sal_index;
+//! use serde::Deserialize;
+//!
+//! #[derive(Debug, Deserialize)]
+//! pub struct ExampleBaseTopic {
+//!     private_origin: i64,
+//!     private_identity: String,
+//!     #[serde(rename = "private_seqNum")]
+//!     private_seq_num: i64,
+//!     #[serde(rename = "private_rcvStamp")]
+//!     private_rcv_stamp: f64,
+//!     #[serde(rename = "salIndex", default = "get_default_sal_index")]
+//!     sal_index: i64,
+//! }
+//! ```
+
 pub mod auth_list;
 pub mod configuration_applied;
 pub mod configurations_available;

--- a/src/generics/set_auth_list.rs
+++ b/src/generics/set_auth_list.rs
@@ -55,7 +55,7 @@ mod tests {
             })
             .collect();
 
-        let topic_schema = avro_schema.get("Test_command_setAuthList").unwrap();
+        let topic_schema = avro_schema.get("command_setAuthList").unwrap();
         let mut topic_record = Record::new(&topic_schema).unwrap();
 
         topic_record.put("authorizedUsers", Value::String("user@hostname".to_owned()));

--- a/src/generics/set_log_level.rs
+++ b/src/generics/set_log_level.rs
@@ -53,7 +53,7 @@ mod tests {
             })
             .collect();
 
-        let topic_schema = avro_schema.get("Test_command_setLogLevel").unwrap();
+        let topic_schema = avro_schema.get("command_setLogLevel").unwrap();
         let mut topic_record = Record::new(&topic_schema).unwrap();
 
         topic_record.put("level", Value::Int(10));

--- a/src/generics/simulation_mode.rs
+++ b/src/generics/simulation_mode.rs
@@ -49,7 +49,7 @@ mod tests {
             })
             .collect();
 
-        let topic_schema = avro_schema.get("Test_logevent_simulationMode").unwrap();
+        let topic_schema = avro_schema.get("logevent_simulationMode").unwrap();
         let mut topic_record = Record::new(&topic_schema).unwrap();
 
         topic_record.put("mode", Value::Int(0));

--- a/src/generics/software_version.rs
+++ b/src/generics/software_version.rs
@@ -70,7 +70,7 @@ mod tests {
             })
             .collect();
 
-        let topic_schema = avro_schema.get("Test_logevent_softwareVersions").unwrap();
+        let topic_schema = avro_schema.get("logevent_softwareVersions").unwrap();
         let mut topic_record = Record::new(&topic_schema).unwrap();
 
         topic_record.put("salVersion", Value::String("vX.Y.Z".to_owned()));

--- a/src/generics/standby.rs
+++ b/src/generics/standby.rs
@@ -42,7 +42,7 @@ mod tests {
             })
             .collect();
 
-        let topic_schema = avro_schema.get("Test_command_standby").unwrap();
+        let topic_schema = avro_schema.get("command_standby").unwrap();
         let mut topic_record = Record::new(&topic_schema).unwrap();
 
         topic_record.put("private_sndStamp", Value::Double(1.234));

--- a/src/generics/start.rs
+++ b/src/generics/start.rs
@@ -50,7 +50,7 @@ mod tests {
             })
             .collect();
 
-        let topic_schema = avro_schema.get("Test_command_start").unwrap();
+        let topic_schema = avro_schema.get("command_start").unwrap();
         let mut topic_record = Record::new(&topic_schema).unwrap();
 
         topic_record.put(

--- a/src/generics/status_code.rs
+++ b/src/generics/status_code.rs
@@ -49,9 +49,7 @@ mod tests {
             })
             .collect();
 
-        let topic_schema = avro_schema
-            .get("GenericCamera_logevent_statusCode")
-            .unwrap();
+        let topic_schema = avro_schema.get("logevent_statusCode").unwrap();
         let mut topic_record = Record::new(&topic_schema).unwrap();
 
         topic_record.put("mask", Value::Int(0));

--- a/src/generics/summary_state.rs
+++ b/src/generics/summary_state.rs
@@ -56,7 +56,7 @@ mod tests {
             })
             .collect();
 
-        let summary_state_schema = avro_schema.get("Test_logevent_summaryState").unwrap();
+        let summary_state_schema = avro_schema.get("logevent_summaryState").unwrap();
         let mut summary_state_record = Record::new(&summary_state_schema).unwrap();
 
         summary_state_record.put("summaryState", Value::Long(2));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,16 @@
-//! # Rust SAL Object.
+//! # Object-Oriented Service Abstraction Layer (SAL).
 //!
 //! This library provides an implementation of [salobj][1] in rust.
 //!
-//! It provides a framework used to develop control software for the Vera
-//! Rubin Observatory. The implementation here is based of the kafka-based
-//! Python implementation.
+//! SALObj is a framework used to develop control software for the Vera
+//! Rubin Observatory. The implementation here is based in the original Python
+//! kafka implementation of the library.
 //!
 //! This library is still under heavy development and is, at the time of this
 //! writing, a rust learning exercise. Maybe in a distant future it will be
 //! adopted by the project.
 //!
-//! Some interesting notes. In Spanish and Portuguese "sal" means "salt", which
+//! An interesting note, in Spanish and Portuguese "sal" means "salt", which
 //! is known to make metal "rust".
 //!
 //! # Version history

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -1,3 +1,9 @@
+//! Client to interact with SAL components.
+//!
+//! A [Remote] is a client/user side tool to communicate with SAL components.
+//! It allows users to send commands and receive events and telemetry to
+//! components.
+
 use crate::domain;
 use crate::sal_info;
 use crate::topics::base_topic::BaseTopic;
@@ -103,8 +109,7 @@ impl<'a> Remote<'a> {
     }
 
     pub fn get_command_schema(&self, command_name: &str) -> Schema {
-        let sal_name = self.sal_info.get_sal_name(command_name);
-        WriteTopic::get_avro_schema(&self.sal_info, &sal_name)
+        WriteTopic::get_avro_schema(&self.sal_info, command_name)
     }
 
     /// Get component index.
@@ -119,9 +124,7 @@ impl<'a> Remote<'a> {
         timeout: Duration,
         wait_done: bool,
     ) -> Result<CommandAck> {
-        let command_sal_name = self.sal_info.get_sal_name(&command_name);
-
-        assert!(self.sal_info.is_command(&command_sal_name));
+        assert!(self.sal_info.is_command(&command_name));
 
         let command = self.commands.get_mut(&command_name).unwrap();
 

--- a/src/sal_enums.rs
+++ b/src/sal_enums.rs
@@ -1,3 +1,5 @@
+//! Standard enumerations and utilities used by the middleware.
+
 use crate::generics::summary_state::SummaryState;
 use apache_avro::types::Value;
 use num_traits::{cast::cast, PrimInt};

--- a/src/sal_info.rs
+++ b/src/sal_info.rs
@@ -86,9 +86,9 @@ use std::env;
 
 ///Information for one SAL component and index.
 pub struct SalInfo<'a> {
-    name: String,
     index: isize,
     component_info: ComponentInfo,
+    /// HashMap with topics schema, key is topic name.
     topic_schema: HashMap<String, Schema>,
     encoder: AvroEncoder<'a>,
     decoder: AvroDecoder<'a>,
@@ -119,7 +119,6 @@ impl<'a> SalInfo<'a> {
             .collect();
 
         SalInfo {
-            name: name.to_owned(),
             index,
             component_info,
             topic_schema,
@@ -140,8 +139,7 @@ impl<'a> SalInfo<'a> {
         result: &str,
         timeout: f32,
     ) -> Record {
-        let sal_name = self.get_sal_name("ackcmd");
-        let mut record = Record::new(self.topic_schema.get(&sal_name).unwrap()).unwrap();
+        let mut record = Record::new(self.topic_schema.get("ackcmd").unwrap()).unwrap();
         record.put("private_seqNum", Value::Int(private_seqnum));
         record.put("ack", Value::Int(ack as i32));
         record.put("error", Value::Int(error));
@@ -166,28 +164,32 @@ impl<'a> SalInfo<'a> {
         self.component_info.get_description()
     }
 
-    /// Get name[:index]
+    /// Get name\[:index\]
     ///
     /// The suffix is only passed if the component is index.
     pub fn get_name_index(&self) -> String {
         if self.is_indexed() {
-            format!("{}:{}", self.name, self.index)
+            format!(
+                "{}:{}",
+                self.component_info.get_component_name(),
+                self.index
+            )
         } else {
-            self.name.to_string()
+            self.component_info.get_component_name()
         }
     }
 
     /// Get component name.
     pub fn get_name(&self) -> String {
-        self.name.clone()
+        self.component_info.get_component_name()
     }
 
     /// Make schema registry topic name
-    pub fn make_topic_name(&self, topic_name: &str) -> String {
+    pub fn make_schema_registry_topic_name(&self, topic_name: &str) -> String {
         format!(
             "lsst.{}.{}.{}",
             self.component_info.get_topic_subname(),
-            self.name,
+            self.component_info.get_component_name(),
             topic_name
         )
         // "lsst.test.Test.logevent_heartbeat".to_owned()
@@ -201,42 +203,42 @@ impl<'a> SalInfo<'a> {
     pub fn make_subject_name(&self, topic_name: &str) -> String {
         format!(
             "{}-value",
-            self.make_topic_name(topic_name)
+            self.make_schema_registry_topic_name(topic_name)
                 .replace(&format!(".{}_", self.get_name()), ".")
         )
     }
 
     /// Get name of all commands topics.
     pub fn get_command_names(&self) -> Vec<String> {
-        self.component_info.get_command_names()
+        self.component_info.get_topic_name_commands()
     }
 
     /// Get names of all events topics.
     pub fn get_event_names(&self) -> Vec<String> {
-        self.component_info.get_event_names()
+        self.component_info.get_topic_name_events()
     }
 
     /// Get names of all telemetry topics.
     pub fn get_telemetry_names(&self) -> Vec<String> {
-        self.component_info.get_telemetry_names()
+        self.component_info.get_topic_name_telemetry()
     }
 
     /// Get names of all the topics.
     pub fn get_topics_name(&self) -> Vec<String> {
         self.get_telemetry_names()
             .into_iter()
-            .map(|topic_name| self.make_topic_name(&topic_name))
+            .map(|topic_name| self.make_schema_registry_topic_name(&topic_name))
             .chain(
                 self.get_event_names()
                     .into_iter()
-                    .map(|topic_name| self.make_topic_name(&topic_name)),
+                    .map(|topic_name| self.make_schema_registry_topic_name(&topic_name)),
             )
             .chain(
                 self.get_command_names()
                     .into_iter()
-                    .map(|topic_name| self.make_topic_name(&topic_name)),
+                    .map(|topic_name| self.make_schema_registry_topic_name(&topic_name)),
             )
-            .chain(vec![self.make_topic_name("ackcmd")])
+            .chain(vec![self.make_schema_registry_topic_name("ackcmd")])
             .collect()
     }
 
@@ -244,57 +246,57 @@ impl<'a> SalInfo<'a> {
     ///
     /// This high-level method will identify if a topic is a command, event,
     /// telemetry or ackcmd and return the appropriate TopicInfo.
-    pub fn get_topic_info(&self, sal_name: &str) -> Option<&TopicInfo> {
-        if self.is_ackcmd(sal_name) {
+    pub fn get_topic_info(&self, topic_name: &str) -> Option<&TopicInfo> {
+        if self.is_ackcmd(topic_name) {
             Some(self.component_info.get_ackcmd_topic_info())
-        } else if self.is_command(sal_name) {
-            self.get_command_topic_info(sal_name)
-        } else if self.is_event(sal_name) {
-            self.get_event_topic_info(sal_name)
+        } else if self.is_command(topic_name) {
+            self.get_command_topic_info(topic_name)
+        } else if self.is_event(topic_name) {
+            self.get_event_topic_info(topic_name)
         } else {
-            self.get_telemetry_topic_info(sal_name)
+            self.get_telemetry_topic_info(topic_name)
         }
     }
 
     /// Check if topic name matches command acknowledgement.
-    fn is_ackcmd(&self, sal_name: &str) -> bool {
-        sal_name == self.get_sal_name("ackcmd")
+    fn is_ackcmd(&self, topic_name: &str) -> bool {
+        topic_name == "ackcmd"
     }
 
     /// Check if topic name matches command name.
     ///
     /// This method does not test if the topic is a valid topic from the
     /// component.
-    pub fn is_command(&self, sal_name: &str) -> bool {
-        sal_name.contains("_command_")
+    pub fn is_command(&self, topic_name: &str) -> bool {
+        topic_name.starts_with("command_")
     }
 
     /// Check if topic name matches event name.
     ///
     /// This method does not test if the topic is a valid topic from the
     /// component.
-    pub fn is_event(&self, sal_name: &str) -> bool {
-        sal_name.contains("_logevent_")
+    pub fn is_event(&self, topic_name: &str) -> bool {
+        topic_name.starts_with("logevent_")
     }
 
     /// Get topic info for a particular command.
-    fn get_command_topic_info(&self, sal_name: &str) -> Option<&TopicInfo> {
-        self.component_info.get_command_topic_info(sal_name)
+    fn get_command_topic_info(&self, topic_name: &str) -> Option<&TopicInfo> {
+        self.component_info.get_topic_info_command(topic_name)
     }
 
     /// Get topic info for a particular event.
-    fn get_event_topic_info(&self, sal_name: &str) -> Option<&TopicInfo> {
-        self.component_info.get_event_topic_info(sal_name)
+    fn get_event_topic_info(&self, topic_name: &str) -> Option<&TopicInfo> {
+        self.component_info.get_topic_info_event(topic_name)
     }
 
     /// Get topic info for a particular telemetry.
-    fn get_telemetry_topic_info(&self, sal_name: &str) -> Option<&TopicInfo> {
-        self.component_info.get_telemetry_topic_info(sal_name)
+    fn get_telemetry_topic_info(&self, topic_name: &str) -> Option<&TopicInfo> {
+        self.component_info.get_topic_info_telemetry(topic_name)
     }
 
     /// Get schema for topic.
-    pub fn get_topic_schema(&self, sal_name: &str) -> Option<&Schema> {
-        self.topic_schema.get(sal_name)
+    pub fn get_topic_schema(&self, topic_name: &str) -> Option<&Schema> {
+        self.topic_schema.get(topic_name)
     }
 
     /// Assert that a topic name is a valid topic for this component.
@@ -303,12 +305,10 @@ impl<'a> SalInfo<'a> {
     ///
     /// If topic name is not part of the component.
     pub fn assert_is_valid_topic(&self, topic_name: &str) {
-        let topic_sal_name = self.get_sal_name(topic_name);
-
         assert!(
-            self.topic_schema.contains_key(&topic_sal_name) || topic_name == "ackcmd",
+            self.topic_schema.contains_key(topic_name) || topic_name == "ackcmd",
             "No topic {} in component {}:: Valid topics are {:?}",
-            topic_sal_name,
+            topic_name,
             self.get_name(),
             self.topic_schema.keys()
         )
@@ -335,7 +335,7 @@ impl<'a> SalInfo<'a> {
         for (topic, avro_schema) in topic_schema.iter() {
             let schema = serde_json::to_string(&avro_schema).unwrap();
             let supplied_schema = SuppliedSchema {
-                name: Some(self.make_topic_name(topic)),
+                name: Some(self.make_schema_registry_topic_name(topic)),
                 schema_type: SchemaType::Avro,
                 schema,
                 references: vec![],
@@ -471,7 +471,7 @@ mod tests {
         let sal_info = SalInfo::new("Test", 1);
 
         // This will panic if fails to get ackcmd
-        sal_info.get_topic_info(&"Test_ackcmd").unwrap();
+        sal_info.get_topic_info(&"ackcmd").unwrap();
     }
 
     #[test]
@@ -479,7 +479,7 @@ mod tests {
         let sal_info = SalInfo::new("Test", 1);
 
         // This will panic if fails to get command
-        sal_info.get_topic_info(&"Test_command_start").unwrap();
+        sal_info.get_topic_info(&"command_start").unwrap();
     }
 
     #[test]
@@ -488,7 +488,7 @@ mod tests {
         let sal_info = SalInfo::new("Test", 1);
 
         // This will panic if fails to get command
-        sal_info.get_topic_info(&"Test_command_startBad").unwrap();
+        sal_info.get_topic_info(&"command_startBad").unwrap();
     }
 
     #[test]
@@ -496,7 +496,7 @@ mod tests {
         let sal_info = SalInfo::new("Test", 1);
 
         // This will panic if fails to get event
-        sal_info.get_topic_info(&"Test_logevent_scalars").unwrap();
+        sal_info.get_topic_info(&"logevent_scalars").unwrap();
     }
 
     #[test]
@@ -505,9 +505,7 @@ mod tests {
         let sal_info = SalInfo::new("Test", 1);
 
         // This will panic if fails to get event
-        sal_info
-            .get_topic_info(&"Test_logevent_scalarsBad")
-            .unwrap();
+        sal_info.get_topic_info(&"logevent_scalarsBad").unwrap();
     }
 
     #[test]
@@ -515,7 +513,7 @@ mod tests {
         let sal_info = SalInfo::new("Test", 1);
 
         // This will panic if fails to get telemetry
-        sal_info.get_topic_info(&"Test_scalars").unwrap();
+        sal_info.get_topic_info(&"scalars").unwrap();
     }
 
     #[test]
@@ -524,6 +522,6 @@ mod tests {
         let sal_info = SalInfo::new("Test", 1);
 
         // This will panic if fails to get telemetry
-        sal_info.get_topic_info(&"Test_scalarsBad").unwrap();
+        sal_info.get_topic_info(&"scalarsBad").unwrap();
     }
 }

--- a/src/sal_info.rs
+++ b/src/sal_info.rs
@@ -1,3 +1,70 @@
+//! Store information about one SAL component and index.
+//!
+//! A SAL component is mostly defined by its name, which maps to an interface.
+//! A component interface is basically a collection of topics. Topics in SAL
+//! comes in 4 different forms; commands, command acknowledgement, events and
+//! telemetry. Each topic category maps to a set of Quality of Service, in the
+//! message passing system and also defines how data should be handled by
+//! components.
+//!
+//! The SalInfo module keeps track of a component interface and provides
+//! utility methods to operate with it.
+//!
+//! # Topic Naming Convention
+//!
+//! SAL topics follow a specific naming convention and, internally, are used in
+//! different contexts. The following is a census of the different ways topics
+//! are referred to in the code.
+//!
+//! * `topic_name`: This is the name of the topic preceded by the type, when it
+//! is an event or a command.
+//!
+//!   Basically:
+//!
+//!   * `logevent_scalars`: Event named `scalars`.
+//!   * `scalars`: Telemetry named `scalars`.
+//!   * `command_setScalars`: Command named `setScalars`.
+//!
+//! * `sal_name`: This is the `topic_name` preceded by the name of the
+//! component.
+//!
+//!   For example:
+//!
+//!   * `Test_logevent_scalars`.
+//!   * `Test_scalars`.
+//!   * `Test_command_setScalars`.
+//!
+//! * `schema_registry_name`: The name of the topic in the schema registry.
+//! This is composed of the static string `lsst`, the topic subname, the
+//! component name and the topic name separated by "dots".
+//!
+//!   For example:
+//!
+//!   * `lsst.test.Test.logevent_scalars`.
+//!   * `lsst.test.Test.scalars`.
+//!   * `lsst.test.Test.command_setScalars`.
+//!
+//!   In the cases above the topic subname is `test`. This is controlled by the
+//! environment variable `LSST_TOPIC_SUBNAME` and allows us to "namespace" the
+//! topics.
+//!
+//! * `subject_name`: This is the name used to register the topic in the kafka
+//! broker. This is composed of the static string `-value` appended to the
+//! `schema_registry_name`, e.g.:
+//!
+//!   * `lsst.test.Test.logevent_scalars-value`.
+//!   * `lsst.test.Test.scalars-value`.
+//!   * `lsst.test.Test.command_setScalars-value`.
+//!
+//! * `namespace`: The namespace of the topic schema. This is used in the topic
+//! avro schema. This consists of the component name appended to the static
+//! string "lsst.sal.kafka-".
+//!
+//!   For example:
+//!
+//!   * `lsst.ts.kafka-Test`.
+//!
+
 use crate::sal_enums;
 use crate::topics::topic_info::TopicInfo;
 use crate::{component_info::ComponentInfo, domain::Domain};

--- a/src/topics/base_topic.rs
+++ b/src/topics/base_topic.rs
@@ -1,3 +1,5 @@
+//! Base topic definition.
+
 use crate::sal_info::SalInfo;
 use apache_avro::types::Record;
 
@@ -14,8 +16,8 @@ pub trait BaseTopic {
     /// `BaseTopic`, use `make_avro_schema` to store the topic schema and this
     /// method to return it. This will make the code faster for runtime topic
     /// creation.
-    fn get_avro_schema(sal_info: &SalInfo, sal_name: &str) -> apache_avro::Schema {
-        sal_info.get_topic_schema(sal_name).unwrap().clone()
+    fn get_avro_schema(sal_info: &SalInfo, topic_name: &str) -> apache_avro::Schema {
+        sal_info.get_topic_schema(topic_name).unwrap().clone()
     }
 
     /// Make data type.

--- a/src/topics/mod.rs
+++ b/src/topics/mod.rs
@@ -1,3 +1,8 @@
+//! Implementation of all topic-related functionality.
+//!
+//! This is a lower-level part of the library implementing SAL topic
+//! definitions and attributes.
+
 pub mod base_topic;
 pub mod field_info;
 pub mod read_topic;

--- a/src/topics/read_topic.rs
+++ b/src/topics/read_topic.rs
@@ -60,11 +60,11 @@ impl ReadTopic {
 
         ReadTopic {
             topic_name: topic_name.to_owned(),
-            topic_publish_name: sal_info.make_topic_name(topic_name),
+            topic_publish_name: sal_info.make_schema_registry_topic_name(topic_name),
             max_history,
             data_queue: VecDeque::with_capacity(DEFAULT_QUEUE_LEN),
             consumer: Consumer::from_hosts(Domain::get_client_hosts())
-                .with_topic(sal_info.make_topic_name(topic_name))
+                .with_topic(sal_info.make_schema_registry_topic_name(topic_name))
                 .with_fallback_offset(fetch_offset)
                 .with_group(format!("{}", domain.get_origin()))
                 .with_offset_storage(GroupOffsetStorage::Kafka)
@@ -90,10 +90,6 @@ impl ReadTopic {
     }
 
     /// Has any data ever been seen for this topic?
-    ///
-    /// # Panic
-    ///
-    /// If sal_info was not started.
     pub fn has_data(&self) -> bool {
         self.current_data.is_some()
     }
@@ -219,7 +215,11 @@ mod tests {
         let topics: Vec<String> = sal_info
             .get_telemetry_names()
             .into_iter()
-            .map(|topic_name| sal_info.make_topic_name(&topic_name).to_owned())
+            .map(|topic_name| {
+                sal_info
+                    .make_schema_registry_topic_name(&topic_name)
+                    .to_owned()
+            })
             .collect();
 
         println!("Loading metadata for topics: {topics:?}");

--- a/src/topics/topic_info.rs
+++ b/src/topics/topic_info.rs
@@ -1,3 +1,10 @@
+//! High-level representation of topics.
+//!
+//! This module contains utilities to represent a component topic structure
+//! in sensible way as well as mechanisms to convert topic definition into
+//! avro schema.
+//!
+
 use crate::topics::field_info;
 use crate::topics::sal_objects::SalTopic;
 use std::collections::{BTreeMap, HashMap, HashSet};
@@ -42,6 +49,11 @@ impl TopicInfo {
         }
     }
 
+    /// Create [TopicInfo] for ackcmd topic.
+    ///
+    /// This topic is not defined in any component schema only in code.
+    ///
+    /// See (SalInfo)[crate::sal_info] for more information.
     pub fn get_ackcmd(component_name: &str, topic_subname: &str, indexed: bool) -> TopicInfo {
         TopicInfo {
             component_name: String::from(component_name),
@@ -90,22 +102,38 @@ impl TopicInfo {
         }
     }
 
+    /// Get topic name.
+    ///
+    /// See (SalInfo)[crate::sal_info] for more information on topic naming
+    /// conventions.
     pub fn get_topic_name(&self) -> &str {
         &self.topic_name
     }
 
+    /// Get topic subname.
+    ///
+    /// See (SalInfo)[crate::sal_info] for more information on topic naming
+    /// conventions.
     pub fn get_topic_subname(&self) -> &str {
         &self.topic_subname
     }
 
+    /// Get a topic sal name.
+    ///
+    /// See (SalInfo)[crate::sal_info] for more information on topic naming
+    /// conventions.
     pub fn get_sal_name(&self) -> String {
         format!("{}_{}", self.component_name, self.topic_name)
     }
 
+    /// Get a [HashSet] with the names of all fields in this topic.
     pub fn get_fields_name(&self) -> HashSet<String> {
         self.fields.keys().cloned().collect()
     }
 
+    /// Get number of partitions in this topic.
+    ///
+    /// This is a Kafka QoS property.
     pub fn get_partitions(&self) -> usize {
         self.partitions
     }
@@ -134,6 +162,12 @@ impl TopicInfo {
     }
 
     /// Get private fields.
+    ///
+    /// Private fields are additional fields included in SAL topics that are
+    /// not defined in the topic basic structure. In a sense having these
+    /// private fields is what makes a topic a SAL topic, in addition to
+    /// conforming with (naming)[crate::sal_info] conventions and other
+    /// details.
     fn get_private_fields(indexed: bool) -> HashMap<String, field_info::FieldInfo> {
         let private_fields = HashMap::from([
             (

--- a/src/topics/write_topic.rs
+++ b/src/topics/write_topic.rs
@@ -112,7 +112,7 @@ impl WriteTopic {
                 _ => continue,
             }
         }
-        let topic_name = sal_info.make_topic_name(&self.get_topic_name());
+        let topic_name = sal_info.make_schema_registry_topic_name(&self.get_topic_name());
         let record_type = self.get_record_type();
 
         let key_strategy =

--- a/src/utils/macros.rs
+++ b/src/utils/macros.rs
@@ -1,4 +1,31 @@
 #[macro_export]
+/// Implement [BaseTopic](crate::topics::base_topic::BaseTopic) trait to a
+/// struct.
+///
+/// If the struct adheres to the SAL
+/// [base topic definition](crate::generics), you only have to
+/// do:
+///
+/// ```
+/// use salobj::{base_topic, topics::topic::Topic, utils::xml_utils::get_default_sal_index};
+/// use serde::Deserialize;
+///
+/// #[derive(Debug, Deserialize)]
+/// pub struct ExampleBaseTopic {
+///     private_origin: i64,
+///     private_identity: String,
+///     #[serde(rename = "private_seqNum")]
+///     private_seq_num: i64,
+///     #[serde(rename = "private_rcvStamp")]
+///     private_rcv_stamp: f64,
+///     #[serde(rename = "salIndex", default = "get_default_sal_index")]
+///     sal_index: i64,
+/// }
+///
+/// base_topic!(ExampleBaseTopic);
+/// ```
+///
+/// to implement it.
 macro_rules! base_topic {
     ($t:ident) => {
         impl Topic for $t {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,3 +1,5 @@
+//! Sub-module to host all utility tools.
+
 pub mod command_ack;
 pub mod csc;
 pub mod macros;

--- a/src/utils/xml_utils.rs
+++ b/src/utils/xml_utils.rs
@@ -56,6 +56,13 @@ pub fn get_default_sal_index() -> i64 {
     0
 }
 
+/// Convert a topic sal_name into its topic name.
+pub fn convert_sal_name_to_topic_name(component_name: &str, topic_name: &str) -> String {
+    topic_name
+        .replace(&format!("{}_", component_name), "")
+        .replace("SALGeneric_", "")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Substantial improvements to module documentation.
The most important change done here was moving to use topic name instead of sal name to reference topic data structure in ``ComponentInfo``.
The majority of the code changes done here was to accommodate this change, the remaining one are mostly cosmetics and ergonomics (renaming methods etc).