### PR TITLE
General improvement in the library to stop using unwrap and return/handle errors instead.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 apache-avro = "0.14.0"
 chrono = "0.4"
-clap = { version = "3.0", features = ["derive"] }
+clap = { version = "4.1.6", features = ["derive"] }
 kafka = "0.9"
 num-traits = "0.2"
 schema_registry_converter = { version = "3.0.0", features = ["avro"] }
@@ -18,6 +18,8 @@ serde_json = "1.0"
 serde-xml-rs = "0.3.1"
 tokio = { version = "1", features = ["full"] }
 whoami = "^1.2"
+log = "0.4.17"
+simple_logger = "4.0.0"
 
 [dev-dependencies]
 num-bigint = "0.4"

--- a/examples/read_test_topic.rs
+++ b/examples/read_test_topic.rs
@@ -24,7 +24,7 @@ async fn main() {
 
     assert!(client.topics().contains(&topic));
 
-    let sal_info = SalInfo::new(component, 1);
+    let sal_info = SalInfo::new(component, 1).unwrap();
     let max_history: usize = 10;
 
     let mut topic_reader = ReadTopic::new(topic, &sal_info, &domain, max_history);

--- a/examples/write_test_topic.rs
+++ b/examples/write_test_topic.rs
@@ -24,7 +24,7 @@ async fn main() {
 
     assert!(client.topics().contains(&topic));
 
-    let sal_info = SalInfo::new(component, 1);
+    let sal_info = SalInfo::new(component, 1).unwrap();
 
     let mut topic_writer = WriteTopic::new(topic, &sal_info, &domain);
 
@@ -34,13 +34,14 @@ async fn main() {
     println!("Writing heartbeat...");
     for i in 0..10 {
         println!("Sending hearbeat {i}...");
-        let mut test_scalars_record = WriteTopic::make_data_type(&schema);
+        let mut test_scalars_record = WriteTopic::make_data_type(&schema).unwrap();
 
         test_scalars_record.put("heartbeat", Value::Boolean(false));
 
         topic_writer
             .write(&mut test_scalars_record, &sal_info)
-            .await;
+            .await
+            .unwrap();
         time::sleep(time::Duration::from_secs(1)).await;
     }
     println!("Done...");

--- a/src/component_info.rs
+++ b/src/component_info.rs
@@ -9,6 +9,7 @@
 //!
 
 use crate::{
+    error::errors::SalObjResult,
     sal_subsystem,
     topics::topic_info::{self, AvroSchema, TopicInfo},
     utils::xml_utils::convert_sal_name_to_topic_name,
@@ -37,9 +38,9 @@ pub struct ComponentInfo {
 }
 
 impl ComponentInfo {
-    pub fn new(name: &str, topic_subname: &str) -> ComponentInfo {
-        let sal_subsystem_set = sal_subsystem::SALSubsystemSet::new();
-        let sal_subsystem_info = sal_subsystem_set.get_sal_subsystem_info(name);
+    pub fn new(name: &str, topic_subname: &str) -> SalObjResult<ComponentInfo> {
+        let sal_subsystem_set = sal_subsystem::SALSubsystemSet::new()?;
+        let sal_subsystem_info = sal_subsystem_set.get_sal_subsystem_info(name)?;
 
         let component_commands: HashMap<String, topic_info::TopicInfo> = sal_subsystem_info
             .get_commands(topic_subname)
@@ -59,7 +60,7 @@ impl ComponentInfo {
             .map(|(sal_name, items)| (convert_sal_name_to_topic_name(name, &sal_name), items))
             .collect();
 
-        ComponentInfo {
+        Ok(ComponentInfo {
             name: String::from(name),
             topic_subname: String::from(topic_subname),
             description: sal_subsystem_info.get_description(),
@@ -72,7 +73,7 @@ impl ComponentInfo {
             commands: component_commands,
             events: component_events,
             telemetry: component_telemetry,
-        }
+        })
     }
 
     /// Get ackcmd topic info.
@@ -177,7 +178,7 @@ mod tests {
 
     #[test]
     fn create_test_component_info() {
-        let component_info = ComponentInfo::new("Test", "unit_test");
+        let component_info = ComponentInfo::new("Test", "unit_test").unwrap();
         let component_info_commands: Vec<&String> =
             component_info.commands.keys().into_iter().collect();
 
@@ -212,7 +213,7 @@ mod tests {
 
     #[test]
     fn make_avro_schema() {
-        let component_info = ComponentInfo::new("Test", "unit_test");
+        let component_info = ComponentInfo::new("Test", "unit_test").unwrap();
 
         let avro_schema: HashMap<String, Schema> = component_info
             .make_avro_schema()

--- a/src/error/errors.rs
+++ b/src/error/errors.rs
@@ -1,24 +1,35 @@
-use std::error::Error;
-use std::fmt;
+use std::{error::Error, fmt, result};
+
+pub type SalObjResult<T> = result::Result<T, SalObjError>;
 
 #[derive(Debug)]
-pub struct NoInterfaceFileError {
+pub struct SalObjError {
     err_msg: String,
 }
 
-impl fmt::Display for NoInterfaceFileError {
+impl fmt::Display for SalObjError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let err_msg = self.err_msg.clone();
         write!(f, "NoInterfaceFileError::{err_msg}")
     }
 }
 
-impl Error for NoInterfaceFileError {}
+impl Error for SalObjError {}
 
-impl NoInterfaceFileError {
-    pub fn new(err_msg: &str) -> NoInterfaceFileError {
-        NoInterfaceFileError {
+impl SalObjError {
+    pub fn new(err_msg: &str) -> SalObjError {
+        SalObjError {
             err_msg: String::from(err_msg),
         }
+    }
+
+    pub fn from_error(error: impl Error) -> SalObjError {
+        SalObjError {
+            err_msg: error.to_string(),
+        }
+    }
+
+    pub fn get_error_message(&self) -> &str {
+        &self.err_msg
     }
 }

--- a/src/generics/auth_list.rs
+++ b/src/generics/auth_list.rs
@@ -42,7 +42,7 @@ mod tests {
 
     #[test]
     fn test_deserialize() {
-        let component_info = ComponentInfo::new("Test", "unit_test");
+        let component_info = ComponentInfo::new("Test", "unit_test").unwrap();
 
         let avro_schema: HashMap<String, Schema> = component_info
             .make_avro_schema()

--- a/src/generics/configuration_applied.rs
+++ b/src/generics/configuration_applied.rs
@@ -54,7 +54,7 @@ mod tests {
 
     #[test]
     fn test_deserialize() {
-        let component_info = ComponentInfo::new("Test", "unit_test");
+        let component_info = ComponentInfo::new("Test", "unit_test").unwrap();
 
         let avro_schema: HashMap<String, Schema> = component_info
             .make_avro_schema()

--- a/src/generics/configurations_available.rs
+++ b/src/generics/configurations_available.rs
@@ -49,7 +49,7 @@ mod tests {
 
     #[test]
     fn test_deserialize() {
-        let component_info = ComponentInfo::new("Test", "unit_test");
+        let component_info = ComponentInfo::new("Test", "unit_test").unwrap();
 
         let avro_schema: HashMap<String, Schema> = component_info
             .make_avro_schema()

--- a/src/generics/disable.rs
+++ b/src/generics/disable.rs
@@ -29,7 +29,7 @@ mod tests {
 
     #[test]
     fn test_deserialize() {
-        let component_info = ComponentInfo::new("Test", "unit_test");
+        let component_info = ComponentInfo::new("Test", "unit_test").unwrap();
 
         let avro_schema: HashMap<String, Schema> = component_info
             .make_avro_schema()

--- a/src/generics/enable.rs
+++ b/src/generics/enable.rs
@@ -29,7 +29,7 @@ mod tests {
 
     #[test]
     fn test_deserialize() {
-        let component_info = ComponentInfo::new("Test", "unit_test");
+        let component_info = ComponentInfo::new("Test", "unit_test").unwrap();
 
         let avro_schema: HashMap<String, Schema> = component_info
             .make_avro_schema()

--- a/src/generics/enter_control.rs
+++ b/src/generics/enter_control.rs
@@ -29,7 +29,7 @@ mod tests {
 
     #[test]
     fn test_deserialize() {
-        let component_info = ComponentInfo::new("ATCamera", "unit_test");
+        let component_info = ComponentInfo::new("ATCamera", "unit_test").unwrap();
 
         let avro_schema: HashMap<String, Schema> = component_info
             .make_avro_schema()

--- a/src/generics/error_code.rs
+++ b/src/generics/error_code.rs
@@ -46,7 +46,7 @@ mod tests {
 
     #[test]
     fn test_deserialize() {
-        let component_info = ComponentInfo::new("Test", "unit_test");
+        let component_info = ComponentInfo::new("Test", "unit_test").unwrap();
 
         let avro_schema: HashMap<String, Schema> = component_info
             .make_avro_schema()

--- a/src/generics/exit_control.rs
+++ b/src/generics/exit_control.rs
@@ -29,7 +29,7 @@ mod tests {
 
     #[test]
     fn test_deserialize() {
-        let component_info = ComponentInfo::new("Test", "unit_test");
+        let component_info = ComponentInfo::new("Test", "unit_test").unwrap();
 
         let avro_schema: HashMap<String, Schema> = component_info
             .make_avro_schema()

--- a/src/generics/heartbeat.rs
+++ b/src/generics/heartbeat.rs
@@ -36,7 +36,7 @@ mod tests {
 
     #[test]
     fn test_deserialize() {
-        let component_info = ComponentInfo::new("Test", "unit_test");
+        let component_info = ComponentInfo::new("Test", "unit_test").unwrap();
 
         let avro_schema: HashMap<String, Schema> = component_info
             .make_avro_schema()

--- a/src/generics/large_file_object_available.rs
+++ b/src/generics/large_file_object_available.rs
@@ -63,7 +63,7 @@ mod tests {
 
     #[test]
     fn test_deserialize() {
-        let component_info = ComponentInfo::new("Script", "unit_test");
+        let component_info = ComponentInfo::new("Script", "unit_test").unwrap();
 
         let avro_schema: HashMap<String, Schema> = component_info
             .make_avro_schema()

--- a/src/generics/log_level.rs
+++ b/src/generics/log_level.rs
@@ -40,7 +40,7 @@ mod tests {
 
     #[test]
     fn test_deserialize() {
-        let component_info = ComponentInfo::new("Test", "unit_test");
+        let component_info = ComponentInfo::new("Test", "unit_test").unwrap();
 
         let avro_schema: HashMap<String, Schema> = component_info
             .make_avro_schema()

--- a/src/generics/log_message.rs
+++ b/src/generics/log_message.rs
@@ -71,7 +71,7 @@ mod tests {
 
     #[test]
     fn test_deserialize() {
-        let component_info = ComponentInfo::new("Test", "unit_test");
+        let component_info = ComponentInfo::new("Test", "unit_test").unwrap();
 
         let avro_schema: HashMap<String, Schema> = component_info
             .make_avro_schema()

--- a/src/generics/set_auth_list.rs
+++ b/src/generics/set_auth_list.rs
@@ -42,7 +42,7 @@ mod tests {
 
     #[test]
     fn test_deserialize() {
-        let component_info = ComponentInfo::new("Test", "unit_test");
+        let component_info = ComponentInfo::new("Test", "unit_test").unwrap();
 
         let avro_schema: HashMap<String, Schema> = component_info
             .make_avro_schema()

--- a/src/generics/set_log_level.rs
+++ b/src/generics/set_log_level.rs
@@ -40,7 +40,7 @@ mod tests {
 
     #[test]
     fn test_deserialize() {
-        let component_info = ComponentInfo::new("Test", "unit_test");
+        let component_info = ComponentInfo::new("Test", "unit_test").unwrap();
 
         let avro_schema: HashMap<String, Schema> = component_info
             .make_avro_schema()

--- a/src/generics/simulation_mode.rs
+++ b/src/generics/simulation_mode.rs
@@ -36,7 +36,7 @@ mod tests {
 
     #[test]
     fn test_deserialize() {
-        let component_info = ComponentInfo::new("Test", "unit_test");
+        let component_info = ComponentInfo::new("Test", "unit_test").unwrap();
 
         let avro_schema: HashMap<String, Schema> = component_info
             .make_avro_schema()

--- a/src/generics/software_version.rs
+++ b/src/generics/software_version.rs
@@ -57,7 +57,7 @@ mod tests {
 
     #[test]
     fn test_deserialize() {
-        let component_info = ComponentInfo::new("Test", "unit_test");
+        let component_info = ComponentInfo::new("Test", "unit_test").unwrap();
 
         let avro_schema: HashMap<String, Schema> = component_info
             .make_avro_schema()

--- a/src/generics/standby.rs
+++ b/src/generics/standby.rs
@@ -29,7 +29,7 @@ mod tests {
 
     #[test]
     fn test_deserialize() {
-        let component_info = ComponentInfo::new("Test", "unit_test");
+        let component_info = ComponentInfo::new("Test", "unit_test").unwrap();
 
         let avro_schema: HashMap<String, Schema> = component_info
             .make_avro_schema()

--- a/src/generics/start.rs
+++ b/src/generics/start.rs
@@ -37,7 +37,7 @@ mod tests {
 
     #[test]
     fn test_deserialize() {
-        let component_info = ComponentInfo::new("Test", "unit_test");
+        let component_info = ComponentInfo::new("Test", "unit_test").unwrap();
 
         let avro_schema: HashMap<String, Schema> = component_info
             .make_avro_schema()

--- a/src/generics/status_code.rs
+++ b/src/generics/status_code.rs
@@ -39,6 +39,7 @@ mod tests {
         let component_info = ComponentInfo::new("GenericCamera", "unit_test");
 
         let avro_schema: HashMap<String, Schema> = component_info
+            .unwrap()
             .make_avro_schema()
             .into_iter()
             .map(|(name, schema)| {

--- a/src/generics/summary_state.rs
+++ b/src/generics/summary_state.rs
@@ -43,7 +43,7 @@ mod tests {
 
     #[test]
     fn test_deserialize() {
-        let component_info = ComponentInfo::new("Test", "unit_test");
+        let component_info = ComponentInfo::new("Test", "unit_test").unwrap();
 
         let avro_schema: HashMap<String, Schema> = component_info
             .make_avro_schema()

--- a/src/sal_enums.rs
+++ b/src/sal_enums.rs
@@ -60,17 +60,17 @@ pub enum SalRetCode {
 }
 
 /// Convert a Value::Long into a SalRetCode enum.
-pub fn get_ackcmd_code(ackcmd: &Value) -> SalRetCode {
+pub fn get_ackcmd_code(ackcmd: Option<&Value>) -> SalRetCode {
     match ackcmd {
-        Value::Long(300) => SalRetCode::CmdAck,
-        Value::Long(301) => SalRetCode::CmdInprogress,
-        Value::Long(302) => SalRetCode::CmdStalled,
-        Value::Long(303) => SalRetCode::CmdComplete,
-        Value::Long(-300) => SalRetCode::CmdNoperm,
-        Value::Long(-301) => SalRetCode::CmdNoack,
-        Value::Long(-302) => SalRetCode::CmdFailed,
-        Value::Long(-303) => SalRetCode::CmdAborted,
-        Value::Long(-304) => SalRetCode::CmdTimeout,
+        Some(Value::Long(300)) => SalRetCode::CmdAck,
+        Some(Value::Long(301)) => SalRetCode::CmdInprogress,
+        Some(Value::Long(302)) => SalRetCode::CmdStalled,
+        Some(Value::Long(303)) => SalRetCode::CmdComplete,
+        Some(Value::Long(-300)) => SalRetCode::CmdNoperm,
+        Some(Value::Long(-301)) => SalRetCode::CmdNoack,
+        Some(Value::Long(-302)) => SalRetCode::CmdFailed,
+        Some(Value::Long(-303)) => SalRetCode::CmdAborted,
+        Some(Value::Long(-304)) => SalRetCode::CmdTimeout,
         _ => SalRetCode::CmdAck,
     }
 }
@@ -119,15 +119,17 @@ impl State {
 
     /// Generate a `State` enumeration from a primitive integer.
     pub fn from<T: PrimInt>(value: T) -> State {
-        let value: u32 = cast(value).unwrap();
-
-        match value {
-            1 => State::Disabled,
-            2 => State::Enabled,
-            3 => State::Fault,
-            4 => State::Offline,
-            5 => State::Standby,
-            _ => State::Invalid,
+        if let Some(value) = cast(value) {
+            match value {
+                1 => State::Disabled,
+                2 => State::Enabled,
+                3 => State::Fault,
+                4 => State::Offline,
+                5 => State::Standby,
+                _ => State::Invalid,
+            }
+        } else {
+            State::Invalid
         }
     }
 }
@@ -164,20 +166,28 @@ mod tests {
 
     #[test]
     fn test_get_ackcmd_code_cmd_default() {
-        assert_eq!(get_ackcmd_code(&Value::Float(10.0)), SalRetCode::CmdAck)
+        assert_eq!(
+            get_ackcmd_code(Some(&Value::Float(10.0))),
+            SalRetCode::CmdAck
+        )
     }
 
     #[test]
     fn test_get_ackcmd_code_cmd_ack() {
-        assert_eq!(get_ackcmd_code(&Value::Long(300)), SalRetCode::CmdAck)
+        assert_eq!(get_ackcmd_code(Some(&Value::Long(300))), SalRetCode::CmdAck)
     }
 
     #[test]
     fn test_get_ackcmd_code_cmd_in_progress() {
         assert_eq!(
-            get_ackcmd_code(&Value::Long(301)),
+            get_ackcmd_code(Some(&Value::Long(301))),
             SalRetCode::CmdInprogress
         )
+    }
+
+    #[test]
+    fn test_get_ackcmd_code_none() {
+        assert_eq!(get_ackcmd_code(None), SalRetCode::CmdAck)
     }
 
     #[test]

--- a/src/topics/base_topic.rs
+++ b/src/topics/base_topic.rs
@@ -16,8 +16,8 @@ pub trait BaseTopic {
     /// `BaseTopic`, use `make_avro_schema` to store the topic schema and this
     /// method to return it. This will make the code faster for runtime topic
     /// creation.
-    fn get_avro_schema(sal_info: &SalInfo, topic_name: &str) -> apache_avro::Schema {
-        sal_info.get_topic_schema(topic_name).unwrap().clone()
+    fn get_avro_schema(sal_info: &SalInfo, topic_name: &str) -> Option<apache_avro::Schema> {
+        sal_info.get_topic_schema(topic_name).cloned()
     }
 
     /// Make data type.
@@ -27,8 +27,7 @@ pub trait BaseTopic {
     /// record, which can be slow to do every single time you want to generate
     /// a topic record. Instead, use this method when creating the topic and
     /// store a copy in your class, then use `get_data_type` to retrieve it.
-    fn make_data_type(avro_schema: &apache_avro::Schema) -> Record {
-        let record = Record::new(avro_schema).unwrap().to_owned();
-        record
+    fn make_data_type(avro_schema: &apache_avro::Schema) -> Option<Record> {
+        Record::new(avro_schema)
     }
 }

--- a/src/topics/remote_command.rs
+++ b/src/topics/remote_command.rs
@@ -8,7 +8,7 @@ use crate::{
 use apache_avro::types::{Record, Value};
 use std::{collections::HashMap, time::Duration};
 
-type Result<T> = std::result::Result<T, T>;
+pub type AckCmdResult = std::result::Result<CommandAck, CommandAck>;
 
 pub struct RemoteCommand {
     command_writer: WriteTopic,
@@ -29,65 +29,70 @@ impl RemoteCommand {
         timeout: Duration,
         wait_done: bool,
         sal_info: &SalInfo<'a>,
-    ) -> Result<CommandAck> {
-        let seq_num = self.command_writer.write(parameters, sal_info).await;
-
+    ) -> AckCmdResult {
         let identity = self.command_writer.get_identity();
         let origin = self.command_writer.get_origin();
-
-        loop {
-            if let Some(Value::Record(ack_cmd)) =
-                self.ack_reader.pop_back(false, timeout, sal_info).await
-            {
-                let data_dict: HashMap<String, Value> = ack_cmd
-                    .into_iter()
-                    .map(|(field, value)| (field, value))
-                    .collect();
-                if *data_dict.get("origin").unwrap() == Value::Long(origin)
-                    && *data_dict.get("identity").unwrap() == Value::String(identity.to_owned())
-                    && *data_dict.get("private_seqNum").unwrap() == Value::Long(seq_num)
+        match self.command_writer.write(parameters, sal_info).await {
+            Ok(seq_num) => loop {
+                if let Some(Value::Record(ack_cmd)) =
+                    self.ack_reader.pop_back(false, timeout, sal_info).await
                 {
-                    let ack = sal_enums::get_ackcmd_code(data_dict.get("ack").unwrap()).clone();
-                    let error: isize = match data_dict.get("error").unwrap() {
-                        Value::Int(error) => *error as isize,
-                        _ => 0,
-                    };
-                    let result = match data_dict.get("result").unwrap() {
-                        Value::String(result) => result.to_owned(),
-                        _ => "".to_string(),
-                    };
+                    let data_dict: HashMap<String, Value> = ack_cmd
+                        .into_iter()
+                        .map(|(field, value)| (field, value))
+                        .collect();
 
-                    let command_ack = CommandAck::new(
-                        ack,
-                        error,
-                        result,
-                        identity.clone(),
+                    if *data_dict.get("origin").unwrap_or(&Value::Long(0)) == Value::Long(origin)
+                        && *data_dict
+                            .get("identity")
+                            .unwrap_or(&Value::String("".to_owned()))
+                            == Value::String(identity.to_owned())
+                        && *data_dict.get("private_seqNum").unwrap_or(&Value::Long(0))
+                            == Value::Long(seq_num)
+                    {
+                        let ack = sal_enums::get_ackcmd_code(data_dict.get("ack")).clone();
+                        let error: isize = match data_dict.get("error") {
+                            Some(Value::Int(error)) => *error as isize,
+                            _ => 0,
+                        };
+                        let result = match data_dict.get("result") {
+                            Some(Value::String(result)) => result.to_owned(),
+                            _ => "".to_string(),
+                        };
+
+                        let command_ack = CommandAck::new(
+                            ack,
+                            error,
+                            result,
+                            identity.clone(),
+                            origin,
+                            timeout,
+                            seq_num,
+                        );
+
+                        if !wait_done {
+                            return Ok(command_ack);
+                        } else if command_ack.is_final() {
+                            if command_ack.is_good() {
+                                return Ok(command_ack);
+                            } else {
+                                return Err(command_ack);
+                            };
+                        }
+                    }
+                } else {
+                    return Err(CommandAck::new(
+                        sal_enums::SalRetCode::CmdNoack,
+                        -1,
+                        "No acknowledgment seen.".to_string(),
+                        identity,
                         origin,
                         timeout,
                         seq_num,
-                    );
-
-                    if !wait_done {
-                        return Ok(command_ack);
-                    } else if command_ack.is_final() {
-                        if command_ack.is_good() {
-                            return Ok(command_ack);
-                        } else {
-                            return Err(command_ack);
-                        };
-                    }
+                    ));
                 }
-            } else {
-                return Err(CommandAck::new(
-                    sal_enums::SalRetCode::CmdNoack,
-                    -1,
-                    "No acknowledgment seen.".to_string(),
-                    identity,
-                    origin,
-                    timeout,
-                    seq_num,
-                ));
-            }
+            },
+            Err(error) => Err(CommandAck::invalid_command(&error.to_string())),
         }
     }
 }

--- a/src/utils/cli.rs
+++ b/src/utils/cli.rs
@@ -1,0 +1,11 @@
+//! Utilities for command line interfaces.
+
+/// Gerenal purpose LogLevel struct that can be used with clap.
+#[derive(clap::ValueEnum, Clone, Debug)]
+pub enum LogLevel {
+    Trace,
+    Debug,
+    Info,
+    Warn,
+    Error,
+}

--- a/src/utils/command_ack.rs
+++ b/src/utils/command_ack.rs
@@ -26,6 +26,20 @@ impl fmt::Display for CommandAck {
     }
 }
 
+impl Default for CommandAck {
+    fn default() -> Self {
+        Self {
+            ack: SalRetCode::CmdAck,
+            error: 0,
+            result: "".to_owned(),
+            identity: "".to_owned(),
+            origin: 0,
+            timeout: std::time::Duration::from_secs(0),
+            seq_num: 0,
+        }
+    }
+}
+
 impl CommandAck {
     pub fn new(
         ack: SalRetCode,
@@ -47,6 +61,12 @@ impl CommandAck {
         }
     }
 
+    pub fn invalid_command(result: &str) -> CommandAck {
+        CommandAck {
+            result: result.to_owned(),
+            ..Default::default()
+        }
+    }
     /// Is the acknowledgement final?
     ///
     /// No more acks should be expected after this.

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,5 +1,6 @@
 //! Sub-module to host all utility tools.
 
+pub mod cli;
 pub mod command_ack;
 pub mod csc;
 pub mod macros;


### PR DESCRIPTION
The original idea of this issue was to refactor the ``Remote`` class to handler failure conditions when instantiating the object. Nevertheless, it turned into a much deeper refactor of the entire codebase to properly handle failures and stop using unwrap all over the place.