### PR TITLE
Make library compatible with latest version of salobj-kafka.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ tokio = { version = "1", features = ["full"] }
 whoami = "^1.2"
 log = "0.4.17"
 simple_logger = "4.0.0"
+md5 = "0.7.0"
 
 [dev-dependencies]
 num-bigint = "0.4"

--- a/base_topic_derive/src/lib.rs
+++ b/base_topic_derive/src/lib.rs
@@ -94,6 +94,30 @@ pub fn add_sal_topic_fields(_args: TokenStream, input: TokenStream) -> TokenStre
                             })
                             .unwrap(),
                     );
+                    fields.named.push(
+                        syn::Field::parse_named
+                            .parse2(quote! {
+                                #[serde(rename = "private_efdStamp")]
+                                private_efd_stamp: f64
+                            })
+                            .unwrap(),
+                    );
+                    fields.named.push(
+                        syn::Field::parse_named
+                            .parse2(quote! {
+                                #[serde(rename = "private_kafkaStamp")]
+                                private_kafka_stamp: f64
+                            })
+                            .unwrap(),
+                    );
+                    fields.named.push(
+                        syn::Field::parse_named
+                            .parse2(quote! {
+                                #[serde(rename = "private_revCode")]
+                                private_rev_code: String
+                            })
+                            .unwrap(),
+                    );
                 }
                 _ => (),
             }

--- a/src/component_info.rs
+++ b/src/component_info.rs
@@ -83,10 +83,7 @@ impl ComponentInfo {
 
     /// Get command topic names.
     pub fn get_topic_name_commands(&self) -> Vec<String> {
-        self.commands
-            .keys()
-            .map(|topic| topic.to_owned())
-            .collect()
+        self.commands.keys().map(|topic| topic.to_owned()).collect()
     }
 
     /// Get command topic info.
@@ -96,10 +93,7 @@ impl ComponentInfo {
 
     /// Get event topic names.
     pub fn get_topic_name_events(&self) -> Vec<String> {
-        self.events
-            .keys()
-            .map(|topic| topic.to_owned())
-            .collect()
+        self.events.keys().map(|topic| topic.to_owned()).collect()
     }
 
     /// Get event topic info.
@@ -235,8 +229,11 @@ mod tests {
             String::from("salIndex"),
             String::from("private_sndStamp"),
             String::from("private_rcvStamp"),
+            String::from("private_efdStamp"),
+            String::from("private_kafkaStamp"),
             String::from("private_seqNum"),
             String::from("private_identity"),
+            String::from("private_revCode"),
             String::from("private_origin"),
             String::from("heartbeat"),
         ]);

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -158,5 +158,4 @@ mod tests {
 
         assert!(controller.is_ok())
     }
-
 }

--- a/src/generics/auth_list.rs
+++ b/src/generics/auth_list.rs
@@ -59,6 +59,9 @@ mod tests {
         topic_record.put("private_seqNum", Value::Long(321));
         topic_record.put("private_rcvStamp", Value::Double(4.321));
         topic_record.put("salIndex", Value::Long(1));
+        topic_record.put("private_efdStamp", Value::Double(1.234));
+        topic_record.put("private_kafkaStamp", Value::Double(1.234));
+        topic_record.put("private_revCode", Value::String("xyz".to_string()));
 
         let mut writer = Writer::with_codec(&topic_schema, Vec::new(), Codec::Deflate);
         writer.append(topic_record).unwrap();

--- a/src/generics/configuration_applied.rs
+++ b/src/generics/configuration_applied.rs
@@ -76,6 +76,9 @@ mod tests {
         topic_record.put("private_seqNum", Value::Long(321));
         topic_record.put("private_rcvStamp", Value::Double(4.321));
         topic_record.put("salIndex", Value::Long(1));
+        topic_record.put("private_efdStamp", Value::Double(1.234));
+        topic_record.put("private_kafkaStamp", Value::Double(1.234));
+        topic_record.put("private_revCode", Value::String("xyz".to_string()));
 
         let mut writer = Writer::with_codec(&topic_schema, Vec::new(), Codec::Deflate);
         writer.append(topic_record).unwrap();

--- a/src/generics/configurations_available.rs
+++ b/src/generics/configurations_available.rs
@@ -73,6 +73,9 @@ mod tests {
         topic_record.put("private_seqNum", Value::Long(321));
         topic_record.put("private_rcvStamp", Value::Double(4.321));
         topic_record.put("salIndex", Value::Long(1));
+        topic_record.put("private_efdStamp", Value::Double(1.234));
+        topic_record.put("private_kafkaStamp", Value::Double(1.234));
+        topic_record.put("private_revCode", Value::String("xyz".to_string()));
 
         let mut writer = Writer::with_codec(&topic_schema, Vec::new(), Codec::Deflate);
         writer.append(topic_record).unwrap();

--- a/src/generics/disable.rs
+++ b/src/generics/disable.rs
@@ -42,6 +42,9 @@ mod tests {
         topic_record.put("private_seqNum", Value::Long(321));
         topic_record.put("private_rcvStamp", Value::Double(4.321));
         topic_record.put("salIndex", Value::Long(1));
+        topic_record.put("private_efdStamp", Value::Double(1.234));
+        topic_record.put("private_kafkaStamp", Value::Double(1.234));
+        topic_record.put("private_revCode", Value::String("xyz".to_string()));
 
         let mut writer = Writer::with_codec(&topic_schema, Vec::new(), Codec::Deflate);
         writer.append(topic_record).unwrap();

--- a/src/generics/enable.rs
+++ b/src/generics/enable.rs
@@ -42,6 +42,9 @@ mod tests {
         topic_record.put("private_seqNum", Value::Long(321));
         topic_record.put("private_rcvStamp", Value::Double(4.321));
         topic_record.put("salIndex", Value::Long(1));
+        topic_record.put("private_efdStamp", Value::Double(1.234));
+        topic_record.put("private_kafkaStamp", Value::Double(1.234));
+        topic_record.put("private_revCode", Value::String("xyz".to_string()));
 
         let mut writer = Writer::with_codec(&topic_schema, Vec::new(), Codec::Deflate);
         writer.append(topic_record).unwrap();

--- a/src/generics/enter_control.rs
+++ b/src/generics/enter_control.rs
@@ -42,6 +42,9 @@ mod tests {
         topic_record.put("private_seqNum", Value::Long(321));
         topic_record.put("private_rcvStamp", Value::Double(4.321));
         topic_record.put("salIndex", Value::Long(0));
+        topic_record.put("private_efdStamp", Value::Double(1.234));
+        topic_record.put("private_kafkaStamp", Value::Double(1.234));
+        topic_record.put("private_revCode", Value::String("xyz".to_string()));
 
         let mut writer = Writer::with_codec(&topic_schema, Vec::new(), Codec::Deflate);
         writer.append(topic_record).unwrap();

--- a/src/generics/error_code.rs
+++ b/src/generics/error_code.rs
@@ -61,6 +61,9 @@ mod tests {
         topic_record.put("private_sndStamp", Value::Double(1.234));
         topic_record.put("private_origin", Value::Long(123));
         topic_record.put("private_identity", Value::String("unit@test".to_string()));
+        topic_record.put("private_efdStamp", Value::Double(1.234));
+        topic_record.put("private_kafkaStamp", Value::Double(1.234));
+        topic_record.put("private_revCode", Value::String("xyz".to_string()));
         topic_record.put("private_seqNum", Value::Long(321));
         topic_record.put("private_rcvStamp", Value::Double(4.321));
         topic_record.put("salIndex", Value::Long(1));

--- a/src/generics/exit_control.rs
+++ b/src/generics/exit_control.rs
@@ -42,6 +42,9 @@ mod tests {
         topic_record.put("private_seqNum", Value::Long(321));
         topic_record.put("private_rcvStamp", Value::Double(4.321));
         topic_record.put("salIndex", Value::Long(1));
+        topic_record.put("private_efdStamp", Value::Double(1.234));
+        topic_record.put("private_kafkaStamp", Value::Double(1.234));
+        topic_record.put("private_revCode", Value::String("xyz".to_string()));
 
         let mut writer = Writer::with_codec(&topic_schema, Vec::new(), Codec::Deflate);
         writer.append(topic_record).unwrap();

--- a/src/generics/heartbeat.rs
+++ b/src/generics/heartbeat.rs
@@ -51,6 +51,9 @@ mod tests {
         topic_record.put("private_seqNum", Value::Long(321));
         topic_record.put("private_rcvStamp", Value::Double(4.321));
         topic_record.put("salIndex", Value::Long(1));
+        topic_record.put("private_efdStamp", Value::Double(1.234));
+        topic_record.put("private_kafkaStamp", Value::Double(1.234));
+        topic_record.put("private_revCode", Value::String("xyz".to_string()));
 
         let mut writer = Writer::with_codec(&topic_schema, Vec::new(), Codec::Deflate);
         writer.append(topic_record).unwrap();

--- a/src/generics/large_file_object_available.rs
+++ b/src/generics/large_file_object_available.rs
@@ -87,6 +87,9 @@ mod tests {
         topic_record.put("private_seqNum", Value::Long(321));
         topic_record.put("private_rcvStamp", Value::Double(4.321));
         topic_record.put("salIndex", Value::Long(1));
+        topic_record.put("private_efdStamp", Value::Double(1.234));
+        topic_record.put("private_kafkaStamp", Value::Double(1.234));
+        topic_record.put("private_revCode", Value::String("xyz".to_string()));
 
         let mut writer = Writer::with_codec(&topic_schema, Vec::new(), Codec::Deflate);
         writer.append(topic_record).unwrap();

--- a/src/generics/log_level.rs
+++ b/src/generics/log_level.rs
@@ -56,6 +56,9 @@ mod tests {
         topic_record.put("private_seqNum", Value::Long(321));
         topic_record.put("private_rcvStamp", Value::Double(4.321));
         topic_record.put("salIndex", Value::Long(1));
+        topic_record.put("private_efdStamp", Value::Double(1.234));
+        topic_record.put("private_kafkaStamp", Value::Double(1.234));
+        topic_record.put("private_revCode", Value::String("xyz".to_string()));
 
         let mut writer = Writer::with_codec(&topic_schema, Vec::new(), Codec::Deflate);
         writer.append(topic_record).unwrap();

--- a/src/generics/log_message.rs
+++ b/src/generics/log_message.rs
@@ -95,6 +95,9 @@ mod tests {
         record.put("private_seqNum", Value::Long(321));
         record.put("private_rcvStamp", Value::Double(4.321));
         record.put("salIndex", Value::Long(1));
+        record.put("private_efdStamp", Value::Double(1.234));
+        record.put("private_kafkaStamp", Value::Double(1.234));
+        record.put("private_revCode", Value::String("xyz".to_string()));
 
         let mut writer = Writer::with_codec(&schema, Vec::new(), Codec::Deflate);
         writer.append(record).unwrap();

--- a/src/generics/set_auth_list.rs
+++ b/src/generics/set_auth_list.rs
@@ -59,6 +59,9 @@ mod tests {
         topic_record.put("private_seqNum", Value::Long(321));
         topic_record.put("private_rcvStamp", Value::Double(4.321));
         topic_record.put("salIndex", Value::Long(1));
+        topic_record.put("private_efdStamp", Value::Double(1.234));
+        topic_record.put("private_kafkaStamp", Value::Double(1.234));
+        topic_record.put("private_revCode", Value::String("xyz".to_string()));
 
         let mut writer = Writer::with_codec(&topic_schema, Vec::new(), Codec::Deflate);
         writer.append(topic_record).unwrap();

--- a/src/generics/set_log_level.rs
+++ b/src/generics/set_log_level.rs
@@ -57,6 +57,9 @@ mod tests {
         topic_record.put("private_seqNum", Value::Long(321));
         topic_record.put("private_rcvStamp", Value::Double(4.321));
         topic_record.put("salIndex", Value::Long(1));
+        topic_record.put("private_efdStamp", Value::Double(1.234));
+        topic_record.put("private_kafkaStamp", Value::Double(1.234));
+        topic_record.put("private_revCode", Value::String("xyz".to_string()));
 
         let mut writer = Writer::with_codec(&topic_schema, Vec::new(), Codec::Deflate);
         writer.append(topic_record).unwrap();

--- a/src/generics/simulation_mode.rs
+++ b/src/generics/simulation_mode.rs
@@ -51,6 +51,9 @@ mod tests {
         topic_record.put("private_seqNum", Value::Long(321));
         topic_record.put("private_rcvStamp", Value::Double(4.321));
         topic_record.put("salIndex", Value::Long(1));
+        topic_record.put("private_efdStamp", Value::Double(1.234));
+        topic_record.put("private_kafkaStamp", Value::Double(1.234));
+        topic_record.put("private_revCode", Value::String("xyz".to_string()));
 
         let mut writer = Writer::with_codec(&topic_schema, Vec::new(), Codec::Deflate);
         writer.append(topic_record).unwrap();

--- a/src/generics/software_version.rs
+++ b/src/generics/software_version.rs
@@ -77,6 +77,9 @@ mod tests {
         topic_record.put("private_seqNum", Value::Long(321));
         topic_record.put("private_rcvStamp", Value::Double(4.321));
         topic_record.put("salIndex", Value::Long(1));
+        topic_record.put("private_efdStamp", Value::Double(1.234));
+        topic_record.put("private_kafkaStamp", Value::Double(1.234));
+        topic_record.put("private_revCode", Value::String("xyz".to_string()));
 
         let mut writer = Writer::with_codec(&topic_schema, Vec::new(), Codec::Deflate);
         writer.append(topic_record).unwrap();

--- a/src/generics/standby.rs
+++ b/src/generics/standby.rs
@@ -42,6 +42,9 @@ mod tests {
         topic_record.put("private_seqNum", Value::Long(321));
         topic_record.put("private_rcvStamp", Value::Double(4.321));
         topic_record.put("salIndex", Value::Long(1));
+        topic_record.put("private_efdStamp", Value::Double(1.234));
+        topic_record.put("private_kafkaStamp", Value::Double(1.234));
+        topic_record.put("private_revCode", Value::String("xyz".to_string()));
 
         let mut writer = Writer::with_codec(&topic_schema, Vec::new(), Codec::Deflate);
         writer.append(topic_record).unwrap();

--- a/src/generics/start.rs
+++ b/src/generics/start.rs
@@ -56,6 +56,9 @@ mod tests {
         topic_record.put("private_seqNum", Value::Long(321));
         topic_record.put("private_rcvStamp", Value::Double(4.321));
         topic_record.put("salIndex", Value::Long(1));
+        topic_record.put("private_efdStamp", Value::Double(1.234));
+        topic_record.put("private_kafkaStamp", Value::Double(1.234));
+        topic_record.put("private_revCode", Value::String("xyz".to_string()));
 
         let mut writer = Writer::with_codec(&topic_schema, Vec::new(), Codec::Deflate);
         writer.append(topic_record).unwrap();

--- a/src/generics/status_code.rs
+++ b/src/generics/status_code.rs
@@ -52,6 +52,9 @@ mod tests {
         topic_record.put("private_seqNum", Value::Long(321));
         topic_record.put("private_rcvStamp", Value::Double(4.321));
         topic_record.put("salIndex", Value::Long(1));
+        topic_record.put("private_efdStamp", Value::Double(1.234));
+        topic_record.put("private_kafkaStamp", Value::Double(1.234));
+        topic_record.put("private_revCode", Value::String("xyz".to_string()));
 
         let mut writer = Writer::with_codec(&topic_schema, Vec::new(), Codec::Deflate);
         writer.append(topic_record).unwrap();

--- a/src/generics/summary_state.rs
+++ b/src/generics/summary_state.rs
@@ -58,6 +58,9 @@ mod tests {
         summary_state_record.put("private_seqNum", Value::Long(321));
         summary_state_record.put("private_rcvStamp", Value::Double(4.321));
         summary_state_record.put("salIndex", Value::Long(1));
+        summary_state_record.put("private_efdStamp", Value::Double(1.234));
+        summary_state_record.put("private_kafkaStamp", Value::Double(1.234));
+        summary_state_record.put("private_revCode", Value::String("xyz".to_string()));
 
         let mut writer = Writer::with_codec(&summary_state_schema, Vec::new(), Codec::Deflate);
         writer.append(summary_state_record).unwrap();

--- a/src/topics/controller_command.rs
+++ b/src/topics/controller_command.rs
@@ -7,7 +7,10 @@ use crate::{
     error::errors::{SalObjError, SalObjResult},
     sal_info::SalInfo,
     topics::{base_topic::BaseTopic, read_topic::ReadTopic, write_topic::WriteTopic},
-    utils::{command_ack::CommandAck, types::{WriteTopicResult, ControllerCallbackFunc}},
+    utils::{
+        command_ack::CommandAck,
+        types::{ControllerCallbackFunc, WriteTopicResult},
+    },
 };
 
 pub struct ControllerCommand {
@@ -41,10 +44,7 @@ impl ControllerCommand {
         self.command_type as i64
     }
 
-    pub fn set_callback(
-        &mut self,
-        callback: ControllerCallbackFunc,
-    ) {
+    pub fn set_callback(&mut self, callback: ControllerCallbackFunc) {
         self.callback = callback
     }
 

--- a/src/topics/sal_objects.rs
+++ b/src/topics/sal_objects.rs
@@ -206,8 +206,8 @@ impl SALObjects {
         if xml_interface.is_ok() {
             let xml_interface = unwrap_xml_interface(xml_interface);
             match serde_xml_rs::from_str(&xml_interface) {
-            Ok(sal_object) => Ok(sal_object),
-            Err(error) => Err(SalObjError::new(&format!("{error:?}"))),
+                Ok(sal_object) => Ok(sal_object),
+                Err(error) => Err(SalObjError::new(&format!("{error:?}"))),
             }
         } else {
             Err(SalObjError::new("Could not read xml interface."))

--- a/src/topics/topic_info.rs
+++ b/src/topics/topic_info.rs
@@ -209,6 +209,26 @@ impl TopicInfo {
                 ),
             ),
             (
+                String::from("private_efdStamp"),
+                field_info::FieldInfo::new(
+                    "private_efdStamp",
+                    "double",
+                    1,
+                    "second",
+                    "UTC time for EFD timestamp. An integer (the number of leap seconds) different from private_sndStamp.",
+                ),
+            ),
+            (
+                String::from("private_kafkaStamp"),
+                field_info::FieldInfo::new(
+                    "private_kafkaStamp",
+                    "double",
+                    1,
+                    "second",
+                    "TAI time at which the Kafka message was created.",
+                ),
+            ),
+            (
                 String::from("private_seqNum"),
                 field_info::FieldInfo::new(
                     "private_seqNum",
@@ -226,6 +246,16 @@ impl TopicInfo {
                     1,
                     "unitless",
                     "Identity of publisher: SAL component name for a CSC or user@host for a user",
+                ),
+            ),
+            (
+                String::from("private_revCode"),
+                field_info::FieldInfo::new(
+                    "private_revCode",
+                    "string",
+                    1,
+                    "unitless",
+                    "Revision hashcode",
                 ),
             ),
             (
@@ -352,8 +382,11 @@ mod tests {
             String::from("salIndex"),
             String::from("private_sndStamp"),
             String::from("private_rcvStamp"),
+            String::from("private_efdStamp"),
+            String::from("private_kafkaStamp"),
             String::from("private_seqNum"),
             String::from("private_identity"),
+            String::from("private_revCode"),
             String::from("private_origin"),
         ]);
 

--- a/src/topics/write_topic.rs
+++ b/src/topics/write_topic.rs
@@ -96,12 +96,13 @@ impl WriteTopic {
         // read current time in microseconds, as int, convert to f32 then
         // convert to seconds.
         self.seq_num += 1;
-        data.put(
-            "private_sndStamp",
-            Value::Double(Utc::now().timestamp_micros() as f64 * 1e-6),
-        );
+        let timestamp = Value::Double(Utc::now().timestamp_micros() as f64 * 1e-6);
+        data.put("private_sndStamp", timestamp.clone());
+        data.put("private_efdStamp", timestamp.clone());
+        data.put("private_kafkaStamp", timestamp);
         data.put("private_origin", Value::Long(self.get_origin()));
         data.put("private_identity", Value::String(self.get_identity()));
+        data.put("private_revCode", Value::String("Not Set".to_owned()));
         data.put(
             "private_seqNum",
             Value::Long(self.seq_num), // FIXME: This is supposed to be an increasing number

--- a/src/utils/csc.rs
+++ b/src/utils/csc.rs
@@ -82,8 +82,7 @@ pub fn compute_state_transitions(
             .position(|state| *state == desired_state)
         {
             let index_range: Vec<usize> = if desired_state_position > current_state_position {
-                (current_state_position..desired_state_position)
-                    .collect()
+                (current_state_position..desired_state_position).collect()
             } else {
                 (desired_state_position + 1..current_state_position + 1)
                     .rev()

--- a/src/utils/types.rs
+++ b/src/utils/types.rs
@@ -1,7 +1,7 @@
-use std::collections::HashMap;
 use apache_avro::types::Value;
-use std::pin::Pin;
+use std::collections::HashMap;
 use std::future::Future;
+use std::pin::Pin;
 
 use crate::{
     error::errors::SalObjError,


### PR DESCRIPTION
For now I only included the missing standard topic attributes. I will change the way the topic schema is parsed, to read the avro schema directly instead of parsing the xml file, in a different issue. 