### PR TITLE
Make WriteTopic.write and ReadTopic.pop_* typed.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+  - repo: local
+    hooks:
+      - id: rustfmt
+        name: rustfmt
+        description: Check if all files follow the rustfmt style
+        entry: cargo fmt --all -- --check --color always
+        language: system
+        pass_filenames: false
+

--- a/base_topic_derive/src/lib.rs
+++ b/base_topic_derive/src/lib.rs
@@ -39,32 +39,32 @@ fn impl_base_topic_trait(ast: DeriveInput) -> TokenStream {
             fn get_sal_index(&self) -> i32 {
                 self.sal_index
             }
-            fn set_private_snd_stamp(&mut self, value: f64) {
-                self.private_snd_stamp = value;
+            fn with_timestamps(mut self) -> Self {
+                let timestamp = Utc::now().timestamp_micros() as f64 * 1e-6;
+                self.private_snd_stamp = timestamp;
+                self.private_efd_stamp = timestamp;
+                self.private_kafka_stamp = timestamp;
+                self
             }
-            fn set_private_efd_stamp(&mut self, value: f64) {
-                self.private_efd_stamp = value;
-            }
-            fn set_private_kafka_stamp(&mut self, value: f64) {
-                self.private_kafka_stamp = value;
-            }
-            fn set_private_origin(&mut self, value: i32) {
+            fn with_private_origin(mut self, value: i32) -> Self {
                 self.private_origin = value;
+                self
             }
-            fn set_private_identity(&mut self, value: &str) {
+            fn with_private_identity(mut self, value: &str) -> Self {
                 self.private_identity = value.to_owned();
+                self
             }
-            fn set_private_rev_code(&mut self, value: &str) {
+            fn with_private_rev_code(mut self, value: &str) -> Self {
                 self.private_rev_code = value.to_owned();
+                self
             }
-            fn set_private_seq_num(&mut self, value: i32) {
+            fn with_private_seq_num(mut self, value: i32) -> Self {
                 self.private_seq_num = value;
+                self
             }
-            fn set_private_rcv_stamp(&mut self, value: f64) {
-                self.private_rcv_stamp = value;
-            }
-            fn set_sal_index(&mut self, value: i32) {
+            fn with_sal_index(mut self, value: i32) -> Self {
                 self.sal_index = value;
+                self
             }
         }
     )

--- a/examples/read_test_topic.rs
+++ b/examples/read_test_topic.rs
@@ -8,7 +8,6 @@ use salobj::{
     topics::{base_topic::BaseTopic, read_topic::ReadTopic},
 };
 use std::time::Duration;
-use tokio::time;
 
 #[tokio::main]
 async fn main() {
@@ -20,7 +19,7 @@ async fn main() {
     let component = "Test";
     let topic = "logevent_heartbeat";
 
-    client.load_metadata(&[topic]);
+    let _ = client.load_metadata(&[topic]);
 
     assert!(client.topics().contains(&topic));
 

--- a/handle_command/src/lib.rs
+++ b/handle_command/src/lib.rs
@@ -2,7 +2,7 @@ extern crate proc_macro;
 
 use convert_case::{Case, Casing};
 use proc_macro::TokenStream;
-use proc_macro2::{TokenStream as TokenStream2};
+use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
 use syn::{parse_macro_input, LitStr, Result, Token};
 

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -105,6 +105,27 @@ impl<'a> Controller<'a> {
         }
     }
 
+    pub fn get_event_to_write<T>(&self, topic_name: &str) -> SalObjResult<T>
+    where
+        T: BaseSALTopic + Default + Debug,
+    {
+        if let Some(writer) = self.events.get(topic_name) {
+            let seq_num = writer.get_seq_num();
+            let origin = writer.get_origin();
+            let identity = writer.get_identity();
+            let sal_index = writer.get_index();
+            let data = T::default()
+                .with_timestamps()
+                .with_private_seq_num(seq_num)
+                .with_private_origin(origin)
+                .with_private_identity(&identity)
+                .with_sal_index(sal_index);
+            Ok(data)
+        } else {
+            Err(SalObjError::new(&format!("No event topic {topic_name}")))
+        }
+    }
+
     pub async fn write_event<T>(&mut self, topic_name: &str, data: &T) -> SalObjResult<i32>
     where
         T: BaseSALTopic + Serialize + Debug,

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -105,30 +105,14 @@ impl<'a> Controller<'a> {
         }
     }
 
-    pub async fn write_event<T>(&mut self, topic_name: &str, data: &mut T) -> SalObjResult<i32>
+    pub async fn write_event<T>(&mut self, topic_name: &str, data: &T) -> SalObjResult<i32>
     where
         T: BaseSALTopic + Serialize + Debug,
     {
         if let Some(writer) = self.events.get_mut(topic_name) {
             writer.write_typed(data).await
-            // if let Ok(data_value) = to_value(data) {
-            //     if let Value::Record(data_record) = data_value {
-            //         let schema = writer.get_schema().clone();
-            //         let mut record = WriteTopic::make_data_type(&schema).unwrap();
-            //         for (field, value) in data_record.into_iter() {
-            //             record.put(&field, value);
-            //         }
-            //         writer.write(&mut record).await
-            //     } else {
-            //         Err(SalObjError::new("Failed to convert value to record."))
-            //     }
-            // } else {
-            //     Err(SalObjError::new("Failed to serialize data."))
-            // }
         } else {
-            Err(SalObjError::new(&format!(
-                "No telemetry topic {topic_name}"
-            )))
+            Err(SalObjError::new(&format!("No event topic {topic_name}")))
         }
     }
 

--- a/src/csc/test_csc/topics/arrays.rs
+++ b/src/csc/test_csc/topics/arrays.rs
@@ -1,5 +1,6 @@
 use crate::{topics::base_sal_topic::BaseSALTopic, utils::xml_utils::get_default_sal_index};
 use base_topic_derive::{add_sal_topic_fields, BaseSALTopic};
+use chrono::Utc;
 
 #[add_sal_topic_fields]
 #[derive(Debug, Deserialize, Serialize, BaseSALTopic, Clone)]

--- a/src/csc/test_csc/topics/scalars.rs
+++ b/src/csc/test_csc/topics/scalars.rs
@@ -1,8 +1,6 @@
-use crate::{
-    topics::base_sal_topic::BaseSALTopic,
-    utils::{xml_utils::get_default_sal_index},
-};
+use crate::{topics::base_sal_topic::BaseSALTopic, utils::xml_utils::get_default_sal_index};
 use base_topic_derive::{add_sal_topic_fields, BaseSALTopic};
+use chrono::Utc;
 
 #[add_sal_topic_fields]
 #[derive(Debug, Deserialize, Serialize, BaseSALTopic, Default, Clone)]

--- a/src/csc/test_csc/topics/wait.rs
+++ b/src/csc/test_csc/topics/wait.rs
@@ -1,5 +1,6 @@
 use crate::{topics::base_sal_topic::BaseSALTopic, utils::xml_utils::get_default_sal_index};
 use base_topic_derive::{add_sal_topic_fields, BaseSALTopic};
+use chrono::Utc;
 
 #[add_sal_topic_fields]
 #[derive(Debug, Deserialize, Default, Serialize, BaseSALTopic, Clone)]

--- a/src/generics/ackcmd.rs
+++ b/src/generics/ackcmd.rs
@@ -1,5 +1,6 @@
 use crate::{topics::base_sal_topic::BaseSALTopic, utils::xml_utils::get_default_sal_index};
 use base_topic_derive::{add_sal_topic_fields, BaseSALTopic};
+use chrono::Utc;
 
 #[add_sal_topic_fields]
 #[derive(Debug, Default, Deserialize, Serialize, BaseSALTopic)]

--- a/src/generics/auth_list.rs
+++ b/src/generics/auth_list.rs
@@ -1,5 +1,6 @@
 use crate::{topics::base_sal_topic::BaseSALTopic, utils::xml_utils::get_default_sal_index};
 use base_topic_derive::{add_sal_topic_fields, BaseSALTopic};
+use chrono::Utc;
 
 #[add_sal_topic_fields]
 #[derive(Debug, Deserialize, BaseSALTopic)]

--- a/src/generics/configuration_applied.rs
+++ b/src/generics/configuration_applied.rs
@@ -1,5 +1,6 @@
 use crate::{topics::base_sal_topic::BaseSALTopic, utils::xml_utils::get_default_sal_index};
 use base_topic_derive::{add_sal_topic_fields, BaseSALTopic};
+use chrono::Utc;
 
 #[add_sal_topic_fields]
 #[derive(Debug, Deserialize, BaseSALTopic)]

--- a/src/generics/configurations_available.rs
+++ b/src/generics/configurations_available.rs
@@ -1,5 +1,6 @@
 use crate::{topics::base_sal_topic::BaseSALTopic, utils::xml_utils::get_default_sal_index};
 use base_topic_derive::{add_sal_topic_fields, BaseSALTopic};
+use chrono::Utc;
 
 #[add_sal_topic_fields]
 #[derive(Debug, Deserialize, BaseSALTopic)]

--- a/src/generics/disable.rs
+++ b/src/generics/disable.rs
@@ -1,5 +1,6 @@
 use crate::{topics::base_sal_topic::BaseSALTopic, utils::xml_utils::get_default_sal_index};
 use base_topic_derive::{add_sal_topic_fields, BaseSALTopic};
+use chrono::Utc;
 
 #[add_sal_topic_fields]
 #[derive(Debug, Deserialize, BaseSALTopic)]

--- a/src/generics/empty_topic.rs
+++ b/src/generics/empty_topic.rs
@@ -1,5 +1,6 @@
 use crate::{topics::base_sal_topic::BaseSALTopic, utils::xml_utils::get_default_sal_index};
 use base_topic_derive::{add_sal_topic_fields, BaseSALTopic};
+use chrono::Utc;
 
 #[add_sal_topic_fields]
 #[derive(Debug, Deserialize, Default, Serialize, BaseSALTopic)]

--- a/src/generics/enable.rs
+++ b/src/generics/enable.rs
@@ -1,5 +1,6 @@
 use crate::{topics::base_sal_topic::BaseSALTopic, utils::xml_utils::get_default_sal_index};
 use base_topic_derive::{add_sal_topic_fields, BaseSALTopic};
+use chrono::Utc;
 
 #[add_sal_topic_fields]
 #[derive(Debug, Deserialize, Default, BaseSALTopic)]

--- a/src/generics/enter_control.rs
+++ b/src/generics/enter_control.rs
@@ -1,5 +1,6 @@
 use crate::{topics::base_sal_topic::BaseSALTopic, utils::xml_utils::get_default_sal_index};
 use base_topic_derive::{add_sal_topic_fields, BaseSALTopic};
+use chrono::Utc;
 
 #[add_sal_topic_fields]
 #[derive(Debug, Deserialize, BaseSALTopic)]

--- a/src/generics/error_code.rs
+++ b/src/generics/error_code.rs
@@ -1,5 +1,6 @@
 use crate::{topics::base_sal_topic::BaseSALTopic, utils::xml_utils::get_default_sal_index};
 use base_topic_derive::{add_sal_topic_fields, BaseSALTopic};
+use chrono::Utc;
 
 #[add_sal_topic_fields]
 #[derive(Debug, Deserialize, BaseSALTopic)]

--- a/src/generics/exit_control.rs
+++ b/src/generics/exit_control.rs
@@ -1,5 +1,6 @@
 use crate::{topics::base_sal_topic::BaseSALTopic, utils::xml_utils::get_default_sal_index};
 use base_topic_derive::{add_sal_topic_fields, BaseSALTopic};
+use chrono::Utc;
 
 #[add_sal_topic_fields]
 #[derive(Debug, Deserialize, Serialize, BaseSALTopic)]

--- a/src/generics/heartbeat.rs
+++ b/src/generics/heartbeat.rs
@@ -1,5 +1,6 @@
 use crate::{topics::base_sal_topic::BaseSALTopic, utils::xml_utils::get_default_sal_index};
 use base_topic_derive::{add_sal_topic_fields, BaseSALTopic};
+use chrono::Utc;
 
 #[add_sal_topic_fields]
 #[derive(Debug, Default, Deserialize, Serialize, BaseSALTopic)]

--- a/src/generics/large_file_object_available.rs
+++ b/src/generics/large_file_object_available.rs
@@ -1,5 +1,6 @@
 use crate::{topics::base_sal_topic::BaseSALTopic, utils::xml_utils::get_default_sal_index};
 use base_topic_derive::{add_sal_topic_fields, BaseSALTopic};
+use chrono::Utc;
 
 #[add_sal_topic_fields]
 #[derive(Debug, Deserialize, BaseSALTopic)]

--- a/src/generics/log_level.rs
+++ b/src/generics/log_level.rs
@@ -1,5 +1,6 @@
 use crate::{topics::base_sal_topic::BaseSALTopic, utils::xml_utils::get_default_sal_index};
 use base_topic_derive::{add_sal_topic_fields, BaseSALTopic};
+use chrono::Utc;
 
 #[add_sal_topic_fields]
 #[derive(Debug, Deserialize, BaseSALTopic)]

--- a/src/generics/log_message.rs
+++ b/src/generics/log_message.rs
@@ -1,5 +1,6 @@
 use crate::{topics::base_sal_topic::BaseSALTopic, utils::xml_utils::get_default_sal_index};
 use base_topic_derive::{add_sal_topic_fields, BaseSALTopic};
+use chrono::Utc;
 
 #[add_sal_topic_fields]
 #[derive(Debug, Deserialize, BaseSALTopic)]

--- a/src/generics/set_auth_list.rs
+++ b/src/generics/set_auth_list.rs
@@ -1,5 +1,6 @@
 use crate::{topics::base_sal_topic::BaseSALTopic, utils::xml_utils::get_default_sal_index};
 use base_topic_derive::{add_sal_topic_fields, BaseSALTopic};
+use chrono::Utc;
 
 #[add_sal_topic_fields]
 #[derive(Debug, Deserialize, BaseSALTopic)]

--- a/src/generics/set_log_level.rs
+++ b/src/generics/set_log_level.rs
@@ -1,5 +1,6 @@
 use crate::{topics::base_sal_topic::BaseSALTopic, utils::xml_utils::get_default_sal_index};
 use base_topic_derive::{add_sal_topic_fields, BaseSALTopic};
+use chrono::Utc;
 
 #[add_sal_topic_fields]
 #[derive(Debug, Deserialize, BaseSALTopic)]

--- a/src/generics/simulation_mode.rs
+++ b/src/generics/simulation_mode.rs
@@ -1,5 +1,6 @@
 use crate::{topics::base_sal_topic::BaseSALTopic, utils::xml_utils::get_default_sal_index};
 use base_topic_derive::{add_sal_topic_fields, BaseSALTopic};
+use chrono::Utc;
 
 #[add_sal_topic_fields]
 #[derive(Debug, Deserialize, BaseSALTopic)]

--- a/src/generics/software_version.rs
+++ b/src/generics/software_version.rs
@@ -1,5 +1,6 @@
 use crate::{topics::base_sal_topic::BaseSALTopic, utils::xml_utils::get_default_sal_index};
 use base_topic_derive::{add_sal_topic_fields, BaseSALTopic};
+use chrono::Utc;
 
 #[add_sal_topic_fields]
 #[derive(Debug, Deserialize, BaseSALTopic)]

--- a/src/generics/standby.rs
+++ b/src/generics/standby.rs
@@ -1,5 +1,6 @@
 use crate::{topics::base_sal_topic::BaseSALTopic, utils::xml_utils::get_default_sal_index};
 use base_topic_derive::{add_sal_topic_fields, BaseSALTopic};
+use chrono::Utc;
 
 #[add_sal_topic_fields]
 #[derive(Debug, Deserialize, BaseSALTopic)]

--- a/src/generics/start.rs
+++ b/src/generics/start.rs
@@ -1,5 +1,6 @@
 use crate::{topics::base_sal_topic::BaseSALTopic, utils::xml_utils::get_default_sal_index};
 use base_topic_derive::{add_sal_topic_fields, BaseSALTopic};
+use chrono::Utc;
 
 #[add_sal_topic_fields]
 #[derive(Debug, Deserialize, BaseSALTopic)]

--- a/src/generics/status_code.rs
+++ b/src/generics/status_code.rs
@@ -1,5 +1,6 @@
 use crate::{topics::base_sal_topic::BaseSALTopic, utils::xml_utils::get_default_sal_index};
 use base_topic_derive::{add_sal_topic_fields, BaseSALTopic};
+use chrono::Utc;
 
 #[add_sal_topic_fields]
 #[derive(Debug, Deserialize, BaseSALTopic)]

--- a/src/generics/summary_state.rs
+++ b/src/generics/summary_state.rs
@@ -2,6 +2,7 @@ use crate::{
     sal_enums::State, topics::base_sal_topic::BaseSALTopic, utils::xml_utils::get_default_sal_index,
 };
 use base_topic_derive::{add_sal_topic_fields, BaseSALTopic};
+use chrono::Utc;
 
 #[add_sal_topic_fields]
 #[derive(Debug, Default, Deserialize, Serialize, BaseSALTopic)]
@@ -19,6 +20,10 @@ impl SummaryState {
         State::from_summary_state(self)
     }
 
+    pub fn with_summary_state(mut self, value: State) -> Self {
+        self.summary_state = value.to::<i32>().unwrap_or(0);
+        self
+    }
     pub fn set_summary_state(&mut self, value: State) {
         self.summary_state = value.to::<i32>().unwrap_or(0);
     }

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -152,7 +152,7 @@ impl<'b> Remote<'b> {
     pub async fn run_command_typed<T>(
         &mut self,
         command_name: &str,
-        data: &mut T,
+        data: &T,
         timeout: Duration,
         wait_done: bool,
     ) -> remote_command::AckCmdResult

--- a/src/topics/base_sal_topic.rs
+++ b/src/topics/base_sal_topic.rs
@@ -6,13 +6,10 @@ pub trait BaseSALTopic {
     fn get_private_seq_num(&self) -> i32;
     fn get_private_rcv_stamp(&self) -> f64;
     fn get_sal_index(&self) -> i32;
-    fn set_private_snd_stamp(&mut self, value: f64);
-    fn set_private_efd_stamp(&mut self, value: f64);
-    fn set_private_kafka_stamp(&mut self, value: f64);
-    fn set_private_origin(&mut self, value: i32);
-    fn set_private_identity(&mut self, value: &str);
-    fn set_private_rev_code(&mut self, value: &str);
-    fn set_private_seq_num(&mut self, value: i32);
-    fn set_private_rcv_stamp(&mut self, value: f64);
-    fn set_sal_index(&mut self, value: i32);
+    fn with_timestamps(self) -> Self;
+    fn with_private_origin(self, value: i32) -> Self;
+    fn with_private_identity(self, value: &str) -> Self;
+    fn with_private_rev_code(self, value: &str) -> Self;
+    fn with_private_seq_num(self, value: i32) -> Self;
+    fn with_sal_index(self, value: i32) -> Self;
 }

--- a/src/topics/controller_command.rs
+++ b/src/topics/controller_command.rs
@@ -19,8 +19,6 @@ pub struct ControllerCommand<'a> {
     command_type: usize,
 }
 
-unsafe impl<'a> Send for ControllerCommand<'a> {}
-
 impl<'a> ControllerCommand<'a> {
     pub fn new(
         command_name: &str,

--- a/src/topics/controller_command.rs
+++ b/src/topics/controller_command.rs
@@ -77,8 +77,12 @@ impl<'a> ControllerCommand<'a> {
     }
 
     pub async fn ack<'si>(&mut self, command_ack: CommandAck) -> WriteTopicResult {
-        let mut ackcmd = command_ack.to_ackcmd();
-        ackcmd.set_private_seq_num(command_ack.get_seq_num());
-        self.ack_writer.write_typed(&mut ackcmd).await
+        let ackcmd = command_ack
+            .to_ackcmd()
+            .with_timestamps()
+            .with_private_origin(self.get_origin() as i32)
+            .with_private_identity(&self.get_identity())
+            .with_private_seq_num(command_ack.get_seq_num());
+        self.ack_writer.write_typed(&ackcmd).await
     }
 }

--- a/src/topics/controller_command.rs
+++ b/src/topics/controller_command.rs
@@ -17,6 +17,8 @@ pub struct ControllerCommand<'a> {
     command_reader: ReadTopic<'a>,
     ack_writer: WriteTopic<'a>,
     command_type: usize,
+    origin: u32,
+    identity: String,
 }
 
 impl<'a> ControllerCommand<'a> {
@@ -31,12 +33,22 @@ impl<'a> ControllerCommand<'a> {
                 command_reader: ReadTopic::new(command_name, sal_info, domain, 0),
                 ack_writer: WriteTopic::new("ackcmd", sal_info, domain),
                 command_type,
+                origin: domain.get_origin(),
+                identity: domain.get_identity(),
             })
         } else {
             Err(SalObjError::new(&format!(
                 "Could not find command type for {command_name}"
             )))
         }
+    }
+
+    pub fn get_identity(&self) -> &str {
+        &self.identity
+    }
+
+    pub fn get_origin(&self) -> u32 {
+        self.origin
     }
 
     pub fn get_command_type(&self) -> i64 {

--- a/src/topics/remote_command.rs
+++ b/src/topics/remote_command.rs
@@ -125,7 +125,7 @@ impl<'a> RemoteCommand<'a> {
 
     pub async fn run_typed<'b, T>(
         &mut self,
-        data: &mut T,
+        data: &T,
         timeout: Duration,
         wait_done: bool,
     ) -> AckCmdResult

--- a/src/topics/remote_command.rs
+++ b/src/topics/remote_command.rs
@@ -35,6 +35,22 @@ impl<'a> RemoteCommand<'a> {
         self.command_writer.get_schema()
     }
 
+    pub fn get_index(&self) -> i32 {
+        self.command_writer.get_index()
+    }
+
+    pub fn get_origin(&self) -> i32 {
+        self.command_writer.get_origin()
+    }
+
+    pub fn get_identity(&self) -> String {
+        self.command_writer.get_identity()
+    }
+
+    pub fn get_seq_num(&self) -> i32 {
+        self.command_writer.get_seq_num()
+    }
+
     pub async fn run<'b>(
         &mut self,
         parameters: &mut Record<'b>,

--- a/src/topics/topic_info.rs
+++ b/src/topics/topic_info.rs
@@ -9,7 +9,6 @@ use apache_avro::Schema;
 
 use crate::error::errors::{SalObjError, SalObjResult};
 
-
 /// Information about one topic.
 pub struct TopicInfo {
     component_name: String,

--- a/src/topics/write_topic.rs
+++ b/src/topics/write_topic.rs
@@ -172,6 +172,10 @@ impl<'a> WriteTopic<'a> {
         }
     }
 
+    pub fn set_seq_num(&mut self, seq_num: i32) {
+        self.seq_num = seq_num
+    }
+
     /// Write the data.
     ///
     /// # Notes

--- a/src/topics/write_topic.rs
+++ b/src/topics/write_topic.rs
@@ -178,64 +178,23 @@ impl<'a> WriteTopic<'a> {
     ///
     /// Originally the `private_sndStamp` has to be tai but this is writing it
     /// as utc. The precision is going to be microseconds.
-    pub async fn write_typed<T>(&mut self, data: &mut T) -> WriteTopicResult
+    pub async fn write_typed<T>(&mut self, data: &T) -> WriteTopicResult
     where
         T: BaseSALTopic + Serialize + Debug,
     {
         // read current time in microseconds, as int, convert to f32 then
         // convert to seconds.
+        if data.get_private_seq_num() != self.seq_num {
+            return Err(SalObjError::new(&format!(
+                "Input data has wrong sequence number. Must be {}, got {}.",
+                self.seq_num,
+                data.get_private_seq_num(),
+            )));
+        }
         self.seq_num += 1;
-        let timestamp = Utc::now().timestamp_micros() as f64 * 1e-6;
-        data.set_private_snd_stamp(timestamp);
-        data.set_private_efd_stamp(timestamp);
-        data.set_private_kafka_stamp(timestamp);
-        data.set_private_origin(self.get_origin());
-        data.set_private_identity(&self.get_identity());
-        data.set_private_rev_code("Not Set");
-        if data.get_private_seq_num() == 0 {
-            data.set_private_seq_num(self.seq_num);
-        }
-        data.set_private_rcv_stamp(0.0);
-        if self.is_indexed() {
-            data.set_sal_index(self.get_index());
-        }
 
         if let Ok(data_value) = to_value(data) {
             if let Value::Record(data_record) = data_value {
-                let mut record = WriteTopic::make_data_type(&self.schema).unwrap();
-                for (field, value) in data_record.into_iter() {
-                    if field == "salIndex" && !self.is_indexed() {
-                        continue;
-                    } else {
-                        match value {
-                            Value::Float(value) => {
-                                record.put(&field, Value::Union(0, Box::new(Value::Float(value))))
-                            }
-                            Value::Double(value) => {
-                                record.put(&field, Value::Union(0, Box::new(Value::Double(value))))
-                            }
-                            Value::Array(array) => {
-                                let new_array = Value::Array(
-                                    array
-                                        .into_iter()
-                                        .map(|value| match value {
-                                            Value::Float(value) => {
-                                                Value::Union(0, Box::new(Value::Float(value)))
-                                            }
-                                            Value::Double(value) => {
-                                                Value::Union(0, Box::new(Value::Double(value)))
-                                            }
-                                            _ => value,
-                                        })
-                                        .collect(),
-                                );
-                                record.put(&field, new_array);
-                            }
-                            _ => record.put(&field, value),
-                        };
-                    }
-                }
-
                 let record_type = self.get_record_type();
 
                 let key_strategy = SubjectNameStrategy::TopicRecordNameStrategy(
@@ -243,10 +202,35 @@ impl<'a> WriteTopic<'a> {
                     record_type,
                 );
 
-                let data_fields: Vec<(&str, Value)> = record
-                    .fields
+                let data_fields: Vec<(&str, Value)> = data_record
                     .iter()
-                    .map(|(k, v)| (&**k, v.clone()))
+                    .map(|(k, v)| match v {
+                        Value::Float(value) => {
+                            (&**k, Value::Union(0, Box::new(Value::Float(value.clone()))))
+                        }
+                        Value::Double(value) => (
+                            &**k,
+                            Value::Union(0, Box::new(Value::Double(value.clone()))),
+                        ),
+                        Value::Array(array) => {
+                            let new_array = Value::Array(
+                                array
+                                    .into_iter()
+                                    .map(|value| match value {
+                                        Value::Float(value) => {
+                                            Value::Union(0, Box::new(Value::Float(value.clone())))
+                                        }
+                                        Value::Double(value) => {
+                                            Value::Union(0, Box::new(Value::Double(value.clone())))
+                                        }
+                                        _ => value.clone(),
+                                    })
+                                    .collect(),
+                            );
+                            (&**k, new_array)
+                        }
+                        _ => (&**k, v.clone()),
+                    })
                     .collect();
 
                 match self.encoder.encode(data_fields, key_strategy).await {
@@ -257,7 +241,7 @@ impl<'a> WriteTopic<'a> {
                                 format!("{{ \"name\": \"{}\" }}", self.schema_registry_topic_name),
                                 bytes,
                             )) {
-                                Ok(_) => Ok(self.seq_num),
+                                Ok(_) => Ok(data.get_private_seq_num()),
                                 Err(error) => Err(SalObjError::from_error(error)),
                             }
                         }

--- a/tests/test_base_csc.rs
+++ b/tests/test_base_csc.rs
@@ -17,16 +17,16 @@ use tokio::task;
 macro_rules! assert_command_fails {
     ($cmd:expr, $remote:ident, $current_state:ident) => {
         if $cmd == "command_setScalars" {
-            let mut scalars = Scalars::default();
-            scalars.set_sal_index(123);
+            // let mut scalars = Scalars::default().with_sal_index(123);
+            let scalars: Scalars = $remote.get_command_data("command_setScalars").unwrap();
             process_command!($cmd, $remote, scalars, $current_state);
         } else if $cmd == "command_setArrays" {
-            let mut array = Arrays::default();
-            array.set_sal_index(123);
+            //let mut array = Arrays::default().with_sal_index(123);
+            let array: Arrays = $remote.get_command_data("command_setArrays").unwrap();
             process_command!($cmd, $remote, array, $current_state);
         } else if $cmd == "command_wait" {
-            let mut wait = Wait::default();
-            wait.set_sal_index(123);
+            // let mut wait = Wait::default().with_sal_index(123);
+            let wait: Wait = $remote.get_command_data("command_wait").unwrap();
             process_command!($cmd, $remote, wait, $current_state);
         }
     };
@@ -35,7 +35,7 @@ macro_rules! assert_command_fails {
 macro_rules! process_command {
     ($cmd:expr, $remote:ident, $data:ident, $current_state:ident) => {
         if let Err(ack_cmd) = $remote
-            .run_command_typed(&$cmd, &mut $data, Duration::from_secs(5), true)
+            .run_command_typed(&$cmd, &$data, Duration::from_secs(5), true)
             .await
         {
             println!("{ack_cmd:?}");


### PR DESCRIPTION
In the end I only implemented the first part of this issue (the typed `WriteTopic` part). The `ReadTopic` part requires a lifetime that I couldn't figure out how to implement. I have a vague idea how to do it by keeping the data in the `ReadTopic` struct and returning a reference to it. However I am not sure this is useful. Besides, converting a read data is pretty straightforward. 

For example, it would be something like this:

```
let data_value = data_reader.pop_front(...).await.unwrap();
let data = from_value::<MyTopic>(&data_value);
```
